### PR TITLE
Generalize strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Unreleased (??)
  - `View` is now a supertrait of `MenuItem`
  - Fixed issues with displaying a slice of menuitems
  - Added `MenuState`, `MenuBuilder::build_with_state` and `Menu::state`
- - `Select` and `NavigationItem` are now generic over their string parameters
+ - `Menu`, `Select` and `NavigationItem` are now generic over their string parameters
  - `Menu::add_items` now accepts owning collections (e.g. `Vec`)
 
 0.3.1 (2023-08-06)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased (??)
  - Fixed issues with displaying a slice of menuitems
  - Added `MenuState`, `MenuBuilder::build_with_state` and `Menu::state`
  - `Select` and `NavigationItem` are now generic over their string parameters
+ - `Menu::add_items` now accepts owning collections (e.g. `Vec`)
 
 0.3.1 (2023-08-06)
 ==================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Unreleased (??)
  - `View` is now a supertrait of `MenuItem`
  - Fixed issues with displaying a slice of menuitems
  - Added `MenuState`, `MenuBuilder::build_with_state` and `Menu::state`
+ - `Select` and `NavigationItem` are now generic over their string parameters
 
 0.3.1 (2023-08-06)
 ==================

--- a/embedded-menu-macros/src/menu.rs
+++ b/embedded-menu-macros/src/menu.rs
@@ -141,8 +141,10 @@ enum MenuItem {
 impl MenuItem {
     fn menu_item_in_ty(&self, events: &Ident) -> TokenStream {
         match self {
-            MenuItem::Nav { .. } => quote!(NavigationItem<'static, #events>),
-            MenuItem::Data { ty, .. } => quote!(Select<'static, #events, #ty>),
+            MenuItem::Nav { .. } => {
+                quote!(NavigationItem<&'static str, &'static str, &'static str, #events>)
+            }
+            MenuItem::Data { ty, .. } => quote!(Select<&'static str, &'static str, #events, #ty>),
         }
     }
 

--- a/embedded-menu-macros/src/menu.rs
+++ b/embedded-menu-macros/src/menu.rs
@@ -520,6 +520,7 @@ pub fn expand_menu(input: DeriveInput) -> syn::Result<TokenStream> {
                 S: IndicatorStyle,
             {
                 menu: Menu<
+                    &'static str,
                     IT,
                     embedded_layout::chain! {
                         #(#menu_items_in_ty),*
@@ -577,7 +578,7 @@ pub fn expand_menu(input: DeriveInput) -> syn::Result<TokenStream> {
             impl #ty_name {
                 fn setup_menu<S, IT, P>(
                     self,
-                    builder: MenuBuilder<IT, NoItems, #events, BinaryColor, P, S>,
+                    builder: MenuBuilder<&'static str, IT, NoItems, #events, BinaryColor, P, S>,
                 ) -> #wrapper<IT, P, S>
                 where
                     S: IndicatorStyle,

--- a/examples/owned.rs
+++ b/examples/owned.rs
@@ -40,7 +40,7 @@ impl SelectValue for TestEnum {
 
 fn main() -> Result<(), core::convert::Infallible> {
     // Use a generator to create owned strings that we give to the menu.
-    let mut items: Vec<Select<_, _, _, _>> = (1..10)
+    let items: Vec<Select<_, _, _, _>> = (1..10)
         .map(|i| format!("Item {}", i))
         .map(|i| Select::new(i, false))
         .collect();
@@ -53,7 +53,7 @@ fn main() -> Result<(), core::convert::Infallible> {
                     "Lorem ipsum dolor sit amet, in per offendit assueverit adversarium, no sed clita adipisci nominati.",
                 ),
         )
-        .add_items(items.as_mut_slice())
+        .add_items(items)
         .build();
 
     let output_settings = OutputSettingsBuilder::new()

--- a/examples/owned.rs
+++ b/examples/owned.rs
@@ -45,7 +45,7 @@ fn main() -> Result<(), core::convert::Infallible> {
         .map(|i| Select::new(i, false))
         .collect();
 
-    let mut menu = Menu::new("Menu")
+    let mut menu = Menu::new(format!("Items: {}", items.len()))
         .add_item(
             NavigationItem::new("Foo", ())
                 .with_marker(">")

--- a/examples/owned.rs
+++ b/examples/owned.rs
@@ -1,0 +1,89 @@
+//! Run using `cargo run --example simple --target x86_64-pc-windows-msvc`
+//!
+//! Navigate using up/down arrows, interact using the Enter key
+
+use embedded_graphics::{pixelcolor::BinaryColor, prelude::Size, Drawable};
+use embedded_graphics_simulator::{
+    sdl2::Keycode, BinaryColorTheme, OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent,
+    Window,
+};
+use embedded_menu::{
+    interaction::InteractionType,
+    items::{select::SelectValue, NavigationItem, Select},
+    Menu,
+};
+
+#[derive(Copy, Clone, PartialEq)]
+pub enum TestEnum {
+    A,
+    B,
+    C,
+}
+
+impl SelectValue for TestEnum {
+    fn next(&self) -> Self {
+        match self {
+            TestEnum::A => TestEnum::B,
+            TestEnum::B => TestEnum::C,
+            TestEnum::C => TestEnum::A,
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        match self {
+            TestEnum::A => "A",
+            TestEnum::B => "AB",
+            TestEnum::C => "ABC",
+        }
+    }
+}
+
+fn main() -> Result<(), core::convert::Infallible> {
+    // Use a generator to create owned strings that we give to the menu.
+    let mut items: Vec<Select<_, _, _, _>> = (1..10)
+        .map(|i| format!("Item {}", i))
+        .map(|i| Select::new(i, false))
+        .collect();
+
+    let mut menu = Menu::new("Menu")
+        .add_item(
+            NavigationItem::new("Foo", ())
+                .with_marker(">")
+                .with_detail_text(
+                    "Lorem ipsum dolor sit amet, in per offendit assueverit adversarium, no sed clita adipisci nominati.",
+                ),
+        )
+        .add_items(items.as_mut_slice())
+        .build();
+
+    let output_settings = OutputSettingsBuilder::new()
+        .theme(BinaryColorTheme::OledBlue)
+        .build();
+    let mut window = Window::new("Menu demonstration", &output_settings);
+
+    'running: loop {
+        let mut display: SimulatorDisplay<BinaryColor> = SimulatorDisplay::new(Size::new(128, 64));
+        menu.update(&display);
+        menu.draw(&mut display).unwrap();
+        window.update(&display);
+
+        for event in window.events() {
+            match event {
+                SimulatorEvent::KeyDown {
+                    keycode,
+                    repeat: false,
+                    ..
+                } => match keycode {
+                    Keycode::Return => menu.interact(InteractionType::Select),
+                    Keycode::Up => menu.interact(InteractionType::Previous),
+                    Keycode::Down => menu.interact(InteractionType::Next),
+                    _ => None,
+                },
+                SimulatorEvent::Quit => break 'running,
+                _ => None,
+            };
+        }
+    }
+
+    Ok(())
+}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -58,16 +58,23 @@ where
         }
     }
 
-    pub fn add_items<I: MenuItem<R>>(
+    pub fn add_items<I, IC>(
         self,
-        item: &mut [I],
-    ) -> MenuBuilder<IT, Chain<MenuItems<'_, I, R>>, R, C, P, S> {
-        item.iter_mut().for_each(|i| i.set_style(&self.style));
+        mut items: IC,
+    ) -> MenuBuilder<IT, Chain<MenuItems<IC, I, R>>, R, C, P, S>
+    where
+        I: MenuItem<R>,
+        IC: AsRef<[I]> + AsMut<[I]>,
+    {
+        items
+            .as_mut()
+            .iter_mut()
+            .for_each(|i| i.set_style(&self.style));
 
         MenuBuilder {
             _return_type: PhantomData,
             title: self.title,
-            items: Chain::new(MenuItems::new(item)),
+            items: Chain::new(MenuItems::new(items)),
             style: self.style,
         }
     }
@@ -95,16 +102,23 @@ where
         }
     }
 
-    pub fn add_items<I: MenuItem<R>>(
+    pub fn add_items<I, IC>(
         self,
-        item: &mut [I],
-    ) -> MenuBuilder<IT, Link<MenuItems<'_, I, R>, Chain<CE>>, R, C, P, S> {
-        item.iter_mut().for_each(|i| i.set_style(&self.style));
+        mut items: IC,
+    ) -> MenuBuilder<IT, Link<MenuItems<IC, I, R>, Chain<CE>>, R, C, P, S>
+    where
+        I: MenuItem<R>,
+        IC: AsRef<[I]> + AsMut<[I]>,
+    {
+        items
+            .as_mut()
+            .iter_mut()
+            .for_each(|i| i.set_style(&self.style));
 
         MenuBuilder {
             _return_type: PhantomData,
             title: self.title,
-            items: self.items.append(MenuItems::new(item)),
+            items: self.items.append(MenuItems::new(items)),
             style: self.style,
         }
     }
@@ -133,16 +147,23 @@ where
         }
     }
 
-    pub fn add_items<I2: MenuItem<R>>(
+    pub fn add_items<I2, IC>(
         self,
-        item: &mut [I2],
-    ) -> MenuBuilder<IT, Link<MenuItems<'_, I2, R>, Link<I, CE>>, R, C, P, S> {
-        item.iter_mut().for_each(|i| i.set_style(&self.style));
+        mut items: IC,
+    ) -> MenuBuilder<IT, Link<MenuItems<IC, I2, R>, Link<I, CE>>, R, C, P, S>
+    where
+        I2: MenuItem<R>,
+        IC: AsRef<[I2]> + AsMut<[I2]>,
+    {
+        items
+            .as_mut()
+            .iter_mut()
+            .for_each(|i| i.set_style(&self.style));
 
         MenuBuilder {
             _return_type: PhantomData,
             title: self.title,
-            items: self.items.append(MenuItems::new(item)),
+            items: self.items.append(MenuItems::new(items)),
             style: self.style,
         }
     }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -10,27 +10,29 @@ use embedded_layout::{
     layout::linear::LinearLayout, object_chain::ChainElement, prelude::*, view_group::ViewGroup,
 };
 
-pub struct MenuBuilder<IT, LL, R, C, P, S>
+pub struct MenuBuilder<T, IT, LL, R, C, P, S>
 where
+    T: AsRef<str>,
     IT: InteractionController,
     C: PixelColor,
     S: IndicatorStyle,
     P: SelectionIndicatorController,
 {
     _return_type: PhantomData<R>,
-    title: &'static str,
+    title: T,
     items: LL,
     style: MenuStyle<C, S, IT, P>,
 }
 
-impl<R, C, S, IT, P> MenuBuilder<IT, NoItems, R, C, P, S>
+impl<T, R, C, S, IT, P> MenuBuilder<T, IT, NoItems, R, C, P, S>
 where
+    T: AsRef<str>,
     C: PixelColor,
     S: IndicatorStyle,
     IT: InteractionController,
     P: SelectionIndicatorController,
 {
-    pub const fn new(title: &'static str, style: MenuStyle<C, S, IT, P>) -> Self {
+    pub const fn new(title: T, style: MenuStyle<C, S, IT, P>) -> Self {
         Self {
             _return_type: PhantomData,
             title,
@@ -40,14 +42,15 @@ where
     }
 }
 
-impl<IT, R, C, P, S> MenuBuilder<IT, NoItems, R, C, P, S>
+impl<T, IT, R, C, P, S> MenuBuilder<T, IT, NoItems, R, C, P, S>
 where
+    T: AsRef<str>,
     IT: InteractionController,
     C: PixelColor,
     P: SelectionIndicatorController,
     S: IndicatorStyle,
 {
-    pub fn add_item<I: MenuItem<R>>(self, mut item: I) -> MenuBuilder<IT, Chain<I>, R, C, P, S> {
+    pub fn add_item<I: MenuItem<R>>(self, mut item: I) -> MenuBuilder<T, IT, Chain<I>, R, C, P, S> {
         item.set_style(&self.style);
 
         MenuBuilder {
@@ -61,7 +64,7 @@ where
     pub fn add_items<I, IC>(
         self,
         mut items: IC,
-    ) -> MenuBuilder<IT, Chain<MenuItems<IC, I, R>>, R, C, P, S>
+    ) -> MenuBuilder<T, IT, Chain<MenuItems<IC, I, R>>, R, C, P, S>
     where
         I: MenuItem<R>,
         IC: AsRef<[I]> + AsMut<[I]>,
@@ -80,8 +83,9 @@ where
     }
 }
 
-impl<IT, CE, R, C, P, S> MenuBuilder<IT, Chain<CE>, R, C, P, S>
+impl<T, IT, CE, R, C, P, S> MenuBuilder<T, IT, Chain<CE>, R, C, P, S>
 where
+    T: AsRef<str>,
     IT: InteractionController,
     Chain<CE>: MenuItemCollection<R>,
     C: PixelColor,
@@ -91,7 +95,7 @@ where
     pub fn add_item<I: MenuItem<R>>(
         self,
         mut item: I,
-    ) -> MenuBuilder<IT, Link<I, Chain<CE>>, R, C, P, S> {
+    ) -> MenuBuilder<T, IT, Link<I, Chain<CE>>, R, C, P, S> {
         item.set_style(&self.style);
 
         MenuBuilder {
@@ -105,7 +109,7 @@ where
     pub fn add_items<I, IC>(
         self,
         mut items: IC,
-    ) -> MenuBuilder<IT, Link<MenuItems<IC, I, R>, Chain<CE>>, R, C, P, S>
+    ) -> MenuBuilder<T, IT, Link<MenuItems<IC, I, R>, Chain<CE>>, R, C, P, S>
     where
         I: MenuItem<R>,
         IC: AsRef<[I]> + AsMut<[I]>,
@@ -124,8 +128,9 @@ where
     }
 }
 
-impl<IT, I, CE, R, C, P, S> MenuBuilder<IT, Link<I, CE>, R, C, P, S>
+impl<T, IT, I, CE, R, C, P, S> MenuBuilder<T, IT, Link<I, CE>, R, C, P, S>
 where
+    T: AsRef<str>,
     IT: InteractionController,
     Link<I, CE>: MenuItemCollection<R> + ChainElement,
     CE: MenuItemCollection<R> + ChainElement,
@@ -136,7 +141,7 @@ where
     pub fn add_item<I2: MenuItem<R>>(
         self,
         mut item: I2,
-    ) -> MenuBuilder<IT, Link<I2, Link<I, CE>>, R, C, P, S> {
+    ) -> MenuBuilder<T, IT, Link<I2, Link<I, CE>>, R, C, P, S> {
         item.set_style(&self.style);
 
         MenuBuilder {
@@ -150,7 +155,7 @@ where
     pub fn add_items<I2, IC>(
         self,
         mut items: IC,
-    ) -> MenuBuilder<IT, Link<MenuItems<IC, I2, R>, Link<I, CE>>, R, C, P, S>
+    ) -> MenuBuilder<T, IT, Link<MenuItems<IC, I2, R>, Link<I, CE>>, R, C, P, S>
     where
         I2: MenuItem<R>,
         IC: AsRef<[I2]> + AsMut<[I2]>,
@@ -169,15 +174,16 @@ where
     }
 }
 
-impl<IT, VG, R, C, P, S> MenuBuilder<IT, VG, R, C, P, S>
+impl<T, IT, VG, R, C, P, S> MenuBuilder<T, IT, VG, R, C, P, S>
 where
+    T: AsRef<str>,
     IT: InteractionController,
     VG: ViewGroup + MenuItemCollection<R>,
     C: PixelColor,
     P: SelectionIndicatorController,
     S: IndicatorStyle,
 {
-    pub fn build(self) -> Menu<IT, VG, R, C, P, S> {
+    pub fn build(self) -> Menu<T, IT, VG, R, C, P, S> {
         let default_timeout = self.style.details_delay.unwrap_or_default();
 
         self.build_with_state(MenuState {
@@ -190,7 +196,7 @@ where
         })
     }
 
-    pub fn build_with_state(self, mut state: MenuState<IT, P, S>) -> Menu<IT, VG, R, C, P, S> {
+    pub fn build_with_state(self, mut state: MenuState<IT, P, S>) -> Menu<T, IT, VG, R, C, P, S> {
         // We have less menu items than before. Avoid crashing.
         let max_idx = self.items.count().saturating_sub(1);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,26 +285,28 @@ where
     }
 }
 
-pub struct Menu<IT, VG, R, C, P, S>
+pub struct Menu<T, IT, VG, R, C, P, S>
 where
+    T: AsRef<str>,
     IT: InteractionController,
     C: PixelColor,
     P: SelectionIndicatorController,
     S: IndicatorStyle,
 {
     _return_type: PhantomData<R>,
-    title: &'static str,
+    title: T,
     items: VG,
     style: MenuStyle<C, S, IT, P>,
     state: MenuState<IT, P, S>,
 }
 
-impl<R, C, S> Menu<Programmed, NoItems, R, C, StaticPosition, S>
+impl<T, R, C, S> Menu<T, Programmed, NoItems, R, C, StaticPosition, S>
 where
+    T: AsRef<str>,
     C: PixelColor,
     S: IndicatorStyle,
 {
-    pub fn new(title: &'static str) -> MenuBuilder<Programmed, NoItems, R, C, StaticPosition, S>
+    pub fn new(title: T) -> MenuBuilder<T, Programmed, NoItems, R, C, StaticPosition, S>
     where
         MenuStyle<C, S, Programmed, StaticPosition>: Default,
     {
@@ -312,23 +314,25 @@ where
     }
 }
 
-impl<IT, R, C, P, S> Menu<IT, NoItems, R, C, P, S>
+impl<T, IT, R, C, P, S> Menu<T, IT, NoItems, R, C, P, S>
 where
+    T: AsRef<str>,
     C: PixelColor,
     S: IndicatorStyle,
     IT: InteractionController,
     P: SelectionIndicatorController,
 {
     pub fn with_style(
-        title: &'static str,
+        title: T,
         style: MenuStyle<C, S, IT, P>,
-    ) -> MenuBuilder<IT, NoItems, R, C, P, S> {
+    ) -> MenuBuilder<T, IT, NoItems, R, C, P, S> {
         MenuBuilder::new(title, style)
     }
 }
 
-impl<IT, VG, R, C, P, S> Menu<IT, VG, R, C, P, S>
+impl<T, IT, VG, R, C, P, S> Menu<T, IT, VG, R, C, P, S>
 where
+    T: AsRef<str>,
     IT: InteractionController,
     VG: MenuItemCollection<R>,
     C: PixelColor,
@@ -372,8 +376,9 @@ where
     }
 }
 
-impl<IT, VG, R, C, P, S> Menu<IT, VG, R, C, P, S>
+impl<T, IT, VG, R, C, P, S> Menu<T, IT, VG, R, C, P, S>
 where
+    T: AsRef<str>,
     IT: InteractionController,
     VG: ViewGroup + MenuItemCollection<R> + StyledMenuItem<BinaryColor, S, IT, P>,
     C: PixelColor + From<Rgb888>,
@@ -429,7 +434,7 @@ where
         let display_area = display.bounding_box();
         let display_size = display_area.size();
 
-        let menu_title = self.header(self.title, display);
+        let menu_title = self.header(self.title.as_ref(), display);
         let title_height = menu_title.size().height as i32;
 
         let menu_height = display_size.height as i32 - title_height;
@@ -507,8 +512,9 @@ where
     }
 }
 
-impl<IT, VG, R, P, S> Menu<IT, VG, R, BinaryColor, P, S>
+impl<T, IT, VG, R, P, S> Menu<T, IT, VG, R, BinaryColor, P, S>
 where
+    T: AsRef<str>,
     IT: InteractionController,
     VG: ViewGroup + MenuItemCollection<R> + StyledMenuItem<BinaryColor, S, IT, P>,
     P: SelectionIndicatorController,
@@ -523,7 +529,7 @@ where
 
         let thin_stroke = PrimitiveStyle::with_stroke(self.style.color, 1);
 
-        let menu_title = self.header(self.title, display);
+        let menu_title = self.header(self.title.as_ref(), display);
         menu_title.draw(display)?;
 
         let menu_height = display_size.height - menu_title.size().height;
@@ -586,8 +592,9 @@ where
     }
 }
 
-impl<IT, VG, R, P, S> Drawable for Menu<IT, VG, R, BinaryColor, P, S>
+impl<T, IT, VG, R, P, S> Drawable for Menu<T, IT, VG, R, BinaryColor, P, S>
 where
+    T: AsRef<str>,
     IT: InteractionController,
     VG: ViewGroup + MenuItemCollection<R> + StyledMenuItem<BinaryColor, S, IT, P>,
     P: SelectionIndicatorController,


### PR DESCRIPTION
This PR replaces previous static and non-static `str`s with generic type parameters, and does the same with the menu item slice in `add_items`. This allows simplifying menu construction in certain cases.