### PR TITLE
Add more types of interaction

### DIFF
--- a/examples/clamped.rs
+++ b/examples/clamped.rs
@@ -1,0 +1,90 @@
+//! Run using `cargo run --example scrolling --target x86_64-pc-windows-msvc`
+
+use embedded_graphics::{pixelcolor::BinaryColor, prelude::Size, Drawable};
+use embedded_graphics_simulator::{
+    sdl2::Keycode, BinaryColorTheme, OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent,
+    Window,
+};
+use embedded_menu::interaction::programmed::Programmed;
+use embedded_menu::interaction::Clamped;
+use embedded_menu::{
+    interaction::InteractionType,
+    items::{select::SelectValue, Select},
+    Menu, MenuStyle,
+};
+
+#[derive(Copy, Clone, PartialEq)]
+pub enum TestEnum {
+    A,
+    B,
+    C,
+}
+
+impl SelectValue for TestEnum {
+    fn next(&self) -> Self {
+        match self {
+            TestEnum::A => TestEnum::B,
+            TestEnum::B => TestEnum::C,
+            TestEnum::C => TestEnum::A,
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        match self {
+            TestEnum::A => "A",
+            TestEnum::B => "AB",
+            TestEnum::C => "ABC",
+        }
+    }
+}
+
+fn main() -> Result<(), core::convert::Infallible> {
+    let style = MenuStyle::new(BinaryColor::On)
+        .with_animated_selection_indicator(10)
+        .with_interaction_controller(Clamped(Programmed));
+
+    let mut menu = Menu::with_style("Menu", style)
+        .add_item(Select::new(" 1 Check this", false).with_detail_text("Description"))
+        .add_item(Select::new(" 2 Check this", false).with_detail_text("Description"))
+        .add_item(Select::new(" 3 Check this", false).with_detail_text("Description"))
+        .add_item(Select::new(" 4 Check this too", TestEnum::A).with_detail_text("Description"))
+        .add_item(Select::new(" 5 Check this too", TestEnum::A).with_detail_text("Description"))
+        .add_item(Select::new(" 6 Check this", true).with_detail_text("Description"))
+        .add_item(Select::new(" 7 Check this too", true).with_detail_text("Description"))
+        .build();
+
+    let output_settings = OutputSettingsBuilder::new()
+        .theme(BinaryColorTheme::OledBlue)
+        .build();
+    let mut window = Window::new("Menu demonstration", &output_settings);
+
+    'running: loop {
+        let mut display: SimulatorDisplay<BinaryColor> = SimulatorDisplay::new(Size::new(128, 64));
+        menu.update(&display);
+        menu.draw(&mut display).unwrap();
+        window.update(&display);
+
+        for event in window.events() {
+            match event {
+                SimulatorEvent::KeyDown {
+                    keycode,
+                    repeat: false,
+                    ..
+                } => match keycode {
+                    Keycode::Return => menu.interact(InteractionType::Select),
+                    Keycode::Up => menu.interact(InteractionType::Previous),
+                    Keycode::Down => menu.interact(InteractionType::Next),
+                    Keycode::PageDown => menu.interact(InteractionType::Forward(7)),
+                    Keycode::PageUp => menu.interact(InteractionType::Backward(7)),
+                    Keycode::Home => menu.interact(InteractionType::Beginning),
+                    Keycode::End => menu.interact(InteractionType::End),
+                    _ => None,
+                },
+                SimulatorEvent::Quit => break 'running,
+                _ => None,
+            };
+        }
+    }
+
+    Ok(())
+}

--- a/examples/interaction_types.rs
+++ b/examples/interaction_types.rs
@@ -1,0 +1,99 @@
+//! Run using `cargo run --example scrolling --target x86_64-pc-windows-msvc`
+
+use embedded_graphics::{pixelcolor::BinaryColor, prelude::Size, Drawable};
+use embedded_graphics_simulator::{
+    sdl2::Keycode, BinaryColorTheme, OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent,
+    Window,
+};
+use embedded_menu::{
+    interaction::InteractionType,
+    items::{select::SelectValue, Select},
+    Menu, MenuStyle,
+};
+
+#[derive(Copy, Clone, PartialEq)]
+pub enum TestEnum {
+    A,
+    B,
+    C,
+}
+
+impl SelectValue for TestEnum {
+    fn next(&self) -> Self {
+        match self {
+            TestEnum::A => TestEnum::B,
+            TestEnum::B => TestEnum::C,
+            TestEnum::C => TestEnum::A,
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        match self {
+            TestEnum::A => "A",
+            TestEnum::B => "AB",
+            TestEnum::C => "ABC",
+        }
+    }
+}
+
+fn main() -> Result<(), core::convert::Infallible> {
+    let style = MenuStyle::new(BinaryColor::On).with_animated_selection_indicator(10);
+
+    let mut menu = Menu::with_style("Menu", style)
+        .add_item(Select::new(" 1 Check this", false).with_detail_text("Description"))
+        .add_item(Select::new(" 2 Check this", false).with_detail_text("Description"))
+        .add_item(Select::new(" 3 Check this", false).with_detail_text("Description"))
+        .add_item(Select::new(" 4 Check this too", TestEnum::A).with_detail_text("Description"))
+        .add_item(Select::new(" 5 Check this too", TestEnum::A).with_detail_text("Description"))
+        .add_item(Select::new(" 6 Check this", true).with_detail_text("Description"))
+        .add_item(Select::new(" 7 Check this too", true).with_detail_text("Description"))
+        .add_item(Select::new(" 8 Check this too", TestEnum::A).with_detail_text("Description"))
+        .add_item(Select::new(" 9 Check this", false).with_detail_text("Description"))
+        .add_item(Select::new("10 Check this too", true).with_detail_text("Description"))
+        .add_item(Select::new("11 Check this", false).with_detail_text("Description"))
+        .add_item(Select::new("12 Check this too", TestEnum::A).with_detail_text("Description"))
+        .add_item(Select::new("13 Check this", false).with_detail_text("Description"))
+        .add_item(Select::new("14 Check this", false).with_detail_text("Description"))
+        .add_item(Select::new("15 Check this", false).with_detail_text("Description"))
+        .add_item(Select::new("16 Check this", false).with_detail_text("Description"))
+        .add_item(Select::new("17 Check this", false).with_detail_text("Description"))
+        .add_item(Select::new("18 Check this", false).with_detail_text("Description"))
+        .add_item(Select::new("19 Check this", false).with_detail_text("Description"))
+        .add_item(Select::new("20 Check this", false).with_detail_text("Description"))
+        .build();
+
+    let output_settings = OutputSettingsBuilder::new()
+        .theme(BinaryColorTheme::OledBlue)
+        .build();
+    let mut window = Window::new("Menu demonstration", &output_settings);
+
+    'running: loop {
+        let mut display: SimulatorDisplay<BinaryColor> = SimulatorDisplay::new(Size::new(128, 64));
+        menu.update(&display);
+        menu.draw(&mut display).unwrap();
+        window.update(&display);
+
+        for event in window.events() {
+            match event {
+                SimulatorEvent::KeyDown {
+                    keycode,
+                    repeat: false,
+                    ..
+                } => match keycode {
+                    Keycode::Return => menu.interact(InteractionType::Select),
+                    Keycode::Up => menu.interact(InteractionType::Previous),
+                    Keycode::Down => menu.interact(InteractionType::Next),
+                    Keycode::PageDown => menu.interact(InteractionType::Forward(7)),
+                    Keycode::PageUp => menu.interact(InteractionType::Backward(7)),
+                    Keycode::Home => menu.interact(InteractionType::Beginning),
+                    Keycode::End => menu.interact(InteractionType::End),
+                    _ => None,
+                },
+                SimulatorEvent::Quit => break 'running,
+                _ => None,
+            };
+        }
+    }
+
+    Ok(())
+}

--- a/src/interaction/mod.rs
+++ b/src/interaction/mod.rs
@@ -1,11 +1,75 @@
 pub mod programmed;
 pub mod single_touch;
 
+/// Clamp the selection around the first and last item, preventing
+/// wrapping to the beginning.
+#[derive(Copy, Clone)]
+pub struct Clamped<T: InteractionController>(pub T);
+
+impl<T: InteractionController + Copy> InteractionController for Clamped<T> {
+    type Input = T::Input;
+    type State = T::State;
+
+    fn fill_area_width(&self, state: &Self::State, max: u32) -> u32 {
+        self.0.fill_area_width(state, max)
+    }
+
+    fn select(
+        &self,
+        _state: &mut Self::State,
+        selected: usize,
+        count: usize,
+        interaction: InteractionType,
+    ) -> usize {
+        match interaction {
+            InteractionType::Previous => {
+                if selected == 0 {
+                    0
+                } else {
+                    selected - 1
+                }
+            }
+            InteractionType::Next => {
+                if selected == count - 1 {
+                    count - 1
+                } else {
+                    selected + 1
+                }
+            }
+            InteractionType::Forward(i) => {
+                if selected + i >= count {
+                    count - 1
+                } else {
+                    selected + i
+                }
+            }
+            InteractionType::Backward(i) => {
+                if selected < i {
+                    0
+                } else {
+                    selected - i
+                }
+            }
+            InteractionType::Beginning => 0,
+            InteractionType::End => count - 1,
+            InteractionType::Select => selected,
+        }
+    }
+
+    fn update(&self, state: &mut Self::State, action: Self::Input) -> Option<InteractionType> {
+        self.0.update(state, action)
+    }
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum InteractionType {
     Previous,
     Next,
     Select,
+    Forward(usize),
+    Backward(usize),
+    Beginning,
+    End,
 }
 
 pub trait InteractionController: Copy {
@@ -13,5 +77,44 @@ pub trait InteractionController: Copy {
     type State: Default + Copy;
 
     fn fill_area_width(&self, state: &Self::State, max: u32) -> u32;
+
+    /// Update the selection index based on the interaction type returned by the
+    /// `update()` function. By default, loops through the list normally.
+    fn select(
+        &self,
+        _state: &mut Self::State,
+        selected: usize,
+        count: usize,
+        interaction: InteractionType,
+    ) -> usize {
+        match interaction {
+            InteractionType::Previous => selected.checked_sub(1).unwrap_or(count - 1),
+            InteractionType::Next => (selected + 1) % count,
+            InteractionType::Forward(i) => {
+                if selected == count - 1 {
+                    0
+                } else if selected + i >= count {
+                    count - 1
+                } else {
+                    selected + i
+                }
+            }
+            InteractionType::Backward(i) => {
+                if selected == 0 {
+                    count - 1
+                } else if selected < i {
+                    0
+                } else {
+                    selected - i
+                }
+            }
+            InteractionType::Beginning => 0,
+            InteractionType::End => count - 1,
+            InteractionType::Select => selected,
+        }
+    }
+
+    /// Transforms an input into an interaction type, applying logic on the
+    /// state if needed.
     fn update(&self, state: &mut Self::State, action: Self::Input) -> Option<InteractionType>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,25 +359,22 @@ where
         }
 
         let count = self.items.count();
-        match self
+        if let Some(interaction) = self
             .style
             .interaction
             .update(&mut self.state.interaction_state, input)
         {
-            Some(InteractionType::Next) => {
-                let selected = (self.state.selected + 1) % count;
+            let selected = self.style.interaction.select(
+                &mut self.state.interaction_state,
+                self.state.selected,
+                count,
+                interaction,
+            );
 
-                self.state.change_selected_item(selected);
-            }
-            Some(InteractionType::Previous) => {
-                let selected = self.state.selected.checked_sub(1).unwrap_or(count - 1);
-
-                self.state.change_selected_item(selected);
-            }
-            Some(InteractionType::Select) => {
+            self.state.change_selected_item(selected);
+            if interaction == InteractionType::Select {
                 return Some(self.items.interact_with(self.state.selected));
             }
-            None => {}
         }
 
         None


### PR DESCRIPTION
These types are useful for the project I'm working on, which assumes that left/right are page up/down. Using "next" 10 times does not really help in this case (I want to clamp selection).

I also added a simple Clamped interaction type which does clamp selection and prevent going to the end of the menu from the beginning.

I could not find a simpler pattern here than asking the interaction controller where the selection should go with regard to the interaction type. I tried doing it in my own code by having a custom interaction controller but it ended up being too complex and requiring more logic than simply adding this method to interaction controller here.

I also added a default implementation to prevent making this a breaking change. Technically only new features were added and existing code should not need to be modified.