### PR TITLE
Add a color invert as a selection indicator

### DIFF
--- a/src/interaction/mod.rs
+++ b/src/interaction/mod.rs
@@ -1,3 +1,5 @@
+use core::hint::unreachable_unchecked;
+
 pub mod programmed;
 pub mod single_touch;
 
@@ -25,6 +27,33 @@ pub enum InteractionType {
     Select,
 }
 
+impl InteractionType {
+    /// Internal function to change the selection based on interaction. Moved
+    /// separated to allow for easier testing.
+    pub(crate) fn calculate_selection(self, selected: usize, count: usize) -> usize {
+        // The lazy evaluation is necessary to prevent overflows.
+        #[allow(clippy::unnecessary_lazy_evaluations)]
+        match self {
+            InteractionType::Next => (selected + 1) % count,
+            InteractionType::Previous => selected.checked_sub(1).unwrap_or(count - 1),
+            InteractionType::Select => unsafe {
+                // This should be handled prior to calling this function. It is okay for
+                // the compiler to optimize this away.
+                unreachable_unchecked();
+            },
+            InteractionType::ForwardWrapping(n) => (selected + n) % count,
+            InteractionType::Forward(n) => selected.saturating_add(n).min(count - 1),
+            InteractionType::BackwardWrapping(n) => selected
+                .checked_sub(n)
+                .unwrap_or_else(|| count - (n - selected) % count),
+            InteractionType::Backward(n) => selected.saturating_sub(n),
+            InteractionType::Beginning => 0,
+            InteractionType::End => count - 1,
+            InteractionType::JumpTo(n) => n.min(count - 1),
+        }
+    }
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum InputState {
     Idle,
@@ -37,4 +66,78 @@ pub trait InputAdapter: Copy {
     type State: Default + Copy;
 
     fn handle_input(&self, state: &mut Self::State, action: Self::Input) -> InputState;
+}
+
+#[test]
+fn selection() {
+    let count = 30;
+    let mut selected = 3;
+    for _ in 0..5 {
+        selected = InteractionType::Previous.calculate_selection(selected, count);
+    }
+    assert_eq!(selected, 28);
+
+    for _ in 0..5 {
+        selected = InteractionType::Next.calculate_selection(selected, count);
+    }
+    assert_eq!(selected, 3);
+
+    for _ in 0..5 {
+        selected = InteractionType::BackwardWrapping(5).calculate_selection(selected, count);
+    }
+    assert_eq!(selected, 8);
+
+    for _ in 0..5 {
+        selected = InteractionType::ForwardWrapping(5).calculate_selection(selected, count);
+    }
+    assert_eq!(selected, 3);
+
+    selected = InteractionType::JumpTo(20).calculate_selection(selected, count);
+    assert_eq!(selected, 20);
+
+    selected = InteractionType::Beginning.calculate_selection(selected, count);
+    assert_eq!(selected, 0);
+
+    selected = InteractionType::End.calculate_selection(selected, count);
+    assert_eq!(selected, 29);
+
+    for _ in 0..5 {
+        selected = InteractionType::Backward(5).calculate_selection(selected, count);
+    }
+    assert_eq!(selected, 4);
+
+    for _ in 0..5 {
+        selected = InteractionType::Forward(5).calculate_selection(selected, count);
+    }
+    assert_eq!(selected, 29);
+}
+
+#[test]
+fn selection_large_stupid_numbers() {
+    let count = 30;
+    let mut selected = 3;
+
+    selected = InteractionType::BackwardWrapping(75).calculate_selection(selected, count);
+    assert_eq!(selected, 18);
+
+    selected = InteractionType::ForwardWrapping(75).calculate_selection(selected, count);
+    assert_eq!(selected, 3);
+
+    selected = InteractionType::BackwardWrapping(100000).calculate_selection(selected, count);
+    assert_eq!(selected, 23);
+
+    selected = InteractionType::ForwardWrapping(100000).calculate_selection(selected, count);
+    assert_eq!(selected, 3);
+
+    selected = InteractionType::JumpTo(100).calculate_selection(selected, count);
+    assert_eq!(selected, 29);
+
+    selected = InteractionType::JumpTo(0).calculate_selection(selected, count);
+    assert_eq!(selected, 0);
+
+    selected = InteractionType::Forward(100000).calculate_selection(selected, count);
+    assert_eq!(selected, 29);
+
+    selected = InteractionType::Backward(100000).calculate_selection(selected, count);
+    assert_eq!(selected, 0);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,6 @@ use crate::{
         StaticPosition,
     },
 };
-use core::hint::unreachable_unchecked;
 use core::marker::PhantomData;
 use embedded_graphics::{
     draw_target::DrawTarget,
@@ -38,30 +37,6 @@ use embedded_text::{
 };
 
 pub use embedded_menu_macros::{Menu, SelectValue};
-
-/// Internal function to change the selection based on interaction. Moved
-/// separated to allow for easier testing.
-fn calculate_selection(selected: usize, count: usize, interaction: InteractionType) -> usize {
-    // The lazy evaluation is necessary to prevent overflows.
-    #[allow(clippy::unnecessary_lazy_evaluations)]
-    match interaction {
-        InteractionType::Next => (selected + 1) % count,
-        InteractionType::Previous => selected.checked_sub(1).unwrap_or(count - 1),
-        InteractionType::Select => unsafe {
-            // This should be handled prior to calling this function.
-            unreachable_unchecked();
-        },
-        InteractionType::ForwardWrapping(n) => (selected + n) % count,
-        InteractionType::Forward(n) => selected.saturating_add(n).min(count - 1),
-        InteractionType::BackwardWrapping(n) => selected
-            .checked_sub(n)
-            .unwrap_or_else(|| count - (n - selected) % count),
-        InteractionType::Backward(n) => selected.saturating_sub(n),
-        InteractionType::Beginning => 0,
-        InteractionType::End => count - 1,
-        InteractionType::JumpTo(n) => n.min(count - 1),
-    }
-}
 
 /// Marker trait necessary to avoid a "conflicting implementations" error.
 pub trait Marker {}
@@ -400,7 +375,7 @@ where
                 return Some(self.items.interact_with(self.state.selected));
             }
 
-            let selected = calculate_selection(self.state.selected, count, interaction);
+            let selected = interaction.calculate_selection(self.state.selected, count);
             self.state.change_selected_item(selected);
         } else {
             self.state.last_input_state = input;
@@ -654,78 +629,4 @@ where
             self.display_list(display)
         }
     }
-}
-
-#[test]
-fn selection() {
-    let count = 30;
-    let mut selected = 3;
-    for _ in 0..5 {
-        selected = calculate_selection(selected, count, InteractionType::Previous);
-    }
-    assert_eq!(selected, 28);
-
-    for _ in 0..5 {
-        selected = calculate_selection(selected, count, InteractionType::Next);
-    }
-    assert_eq!(selected, 3);
-
-    for _ in 0..5 {
-        selected = calculate_selection(selected, count, InteractionType::BackwardWrapping(5));
-    }
-    assert_eq!(selected, 8);
-
-    for _ in 0..5 {
-        selected = calculate_selection(selected, count, InteractionType::ForwardWrapping(5));
-    }
-    assert_eq!(selected, 3);
-
-    selected = calculate_selection(selected, count, InteractionType::JumpTo(20));
-    assert_eq!(selected, 20);
-
-    selected = calculate_selection(selected, count, InteractionType::Beginning);
-    assert_eq!(selected, 0);
-
-    selected = calculate_selection(selected, count, InteractionType::End);
-    assert_eq!(selected, 29);
-
-    for _ in 0..5 {
-        selected = calculate_selection(selected, count, InteractionType::Backward(5));
-    }
-    assert_eq!(selected, 4);
-
-    for _ in 0..5 {
-        selected = calculate_selection(selected, count, InteractionType::Forward(5));
-    }
-    assert_eq!(selected, 29);
-}
-
-#[test]
-fn selection_large_stupid_numbers() {
-    let count = 30;
-    let mut selected = 3;
-
-    selected = calculate_selection(selected, count, InteractionType::BackwardWrapping(75));
-    assert_eq!(selected, 18);
-
-    selected = calculate_selection(selected, count, InteractionType::ForwardWrapping(75));
-    assert_eq!(selected, 3);
-
-    selected = calculate_selection(selected, count, InteractionType::BackwardWrapping(100000));
-    assert_eq!(selected, 23);
-
-    selected = calculate_selection(selected, count, InteractionType::ForwardWrapping(100000));
-    assert_eq!(selected, 3);
-
-    selected = calculate_selection(selected, count, InteractionType::JumpTo(100));
-    assert_eq!(selected, 29);
-
-    selected = calculate_selection(selected, count, InteractionType::JumpTo(0));
-    assert_eq!(selected, 0);
-
-    selected = calculate_selection(selected, count, InteractionType::Forward(100000));
-    assert_eq!(selected, 29);
-
-    selected = calculate_selection(selected, count, InteractionType::Backward(100000));
-    assert_eq!(selected, 0);
 }

--- a/src/selection_indicator/mod.rs
+++ b/src/selection_indicator/mod.rs
@@ -204,7 +204,10 @@ where
             &state.state,
             Rectangle::new(
                 Point::new(0, screen_offset),
-                Size::new(fill_width, selected_height),
+                Size::new(
+                    fill_width,
+                    (selected_height as i32 + margin_top + margin_bottom) as u32,
+                ),
             ),
             fill_width,
         ));

--- a/src/selection_indicator/style/invert.rs
+++ b/src/selection_indicator/style/invert.rs
@@ -1,0 +1,58 @@
+use crate::interaction::InputState;
+use crate::margin::Insets;
+use crate::selection_indicator::style::{interpolate, IndicatorStyle};
+use embedded_graphics::draw_target::DrawTarget;
+use embedded_graphics::geometry::Size;
+use embedded_graphics::pixelcolor::BinaryColor;
+use embedded_graphics::prelude::Primitive;
+use embedded_graphics::primitives::{PrimitiveStyle, Rectangle};
+use embedded_graphics::Drawable;
+
+#[derive(Clone, Copy)]
+pub struct Invert;
+
+impl IndicatorStyle for Invert {
+    type Shape = Rectangle;
+    type State = ();
+
+    fn margin(&self, _state: &Self::State, _height: u32) -> Insets {
+        Insets {
+            left: 2,
+            top: 1,
+            right: 1,
+            bottom: 1,
+        }
+    }
+
+    fn shape(&self, _state: &Self::State, bounds: Rectangle, _fill_width: u32) -> Self::Shape {
+        bounds
+    }
+
+    fn draw<D>(
+        &self,
+        _state: &Self::State,
+        input_state: InputState,
+        display: &mut D,
+    ) -> Result<u32, D::Error>
+    where
+        D: DrawTarget<Color = BinaryColor>,
+    {
+        let display_area = display.bounding_box();
+
+        let fill_width = display_area.size.width + 1
+            - if let InputState::InProgress(progress) = input_state {
+                interpolate(progress as u32, 0, 255, 0, display_area.size.width)
+            } else {
+                0
+            };
+
+        Rectangle::new(
+            display_area.top_left,
+            Size::new(fill_width, display_area.size.height),
+        )
+        .into_styled(PrimitiveStyle::with_fill(BinaryColor::On))
+        .draw(display)?;
+
+        Ok(fill_width)
+    }
+}

--- a/src/selection_indicator/style/mod.rs
+++ b/src/selection_indicator/style/mod.rs
@@ -8,8 +8,16 @@ use crate::{interaction::InputState, selection_indicator::Insets};
 
 pub mod animated_triangle;
 pub mod border;
+pub mod invert;
 pub mod line;
 pub mod triangle;
+
+// Re-export the styles themselves to make them easier to use.
+pub use animated_triangle::AnimatedTriangle;
+pub use border::Border;
+pub use invert::Invert;
+pub use line::Line;
+pub use triangle::Triangle;
 
 pub fn interpolate(value: u32, x_min: u32, x_max: u32, y_min: u32, y_max: u32) -> u32 {
     let x_range = x_max - x_min;
@@ -41,4 +49,12 @@ pub trait IndicatorStyle: Clone + Copy {
     ) -> Result<u32, D::Error>
     where
         D: DrawTarget<Color = BinaryColor>;
+}
+
+#[test]
+fn interpolate_basic() {
+    assert_eq!(interpolate(0, 0, 100, 0, 100), 0);
+    assert_eq!(interpolate(50, 0, 100, 0, 100), 50);
+    assert_eq!(interpolate(100, 0, 100, 0, 100), 100);
+    assert_eq!(interpolate(100, 0, 10, 0, 100), 1000);
 }


### PR DESCRIPTION
It seems a bug in interpolate was introduced, which makes single touch act weird. But since it happens to all other selectors I didn't think it was in my code.