### PR TITLE
Allow the selected item R value to be returned without interacting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Unreleased
+==================
+ - New: allow `Menu` to return the selected item's R value without interacting with it.
+
 0.5.3 (2023-10-19)
 ==================
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -41,17 +41,19 @@ impl SelectValue for TestEnum {
 
 fn main() -> Result<(), core::convert::Infallible> {
     let mut menu = Menu::new("Menu")
-        .add_item(NavigationItem::new("Foo", ()).with_marker(">"))
-        .add_item(Select::new("Check this 1", false))
+        .add_item(NavigationItem::new("Foo", 1).with_marker(">"))
+        .add_item(Select::new("Check this 1", false).with_value_converter(|b| 20 + b as i32))
         .add_item(SectionTitle::new("===== Section ====="))
-        .add_item(Select::new("Check this 2", false))
-        .add_item(Select::new("Check this 3", TestEnum::A))
+        .add_item(Select::new("Check this 2", false).with_value_converter(|b| 30 + b as i32))
+        .add_item(Select::new("Check this 3", TestEnum::A).with_value_converter(|b| 40 + b as i32))
         .build();
 
     let output_settings = OutputSettingsBuilder::new()
         .theme(BinaryColorTheme::OledBlue)
         .build();
     let mut window = Window::new("Menu demonstration", &output_settings);
+
+    let mut selected_value: i32 = 0;
 
     'running: loop {
         let mut display: SimulatorDisplay<BinaryColor> = SimulatorDisplay::new(Size::new(128, 64));
@@ -74,6 +76,12 @@ fn main() -> Result<(), core::convert::Infallible> {
                 SimulatorEvent::Quit => break 'running,
                 _ => None,
             };
+        }
+
+        let selected = menu.selected_value();
+        if selected != selected_value {
+            println!("Selected value: {}", selected);
+            selected_value = selected;
         }
     }
 

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -18,6 +18,7 @@ pub trait MenuItemCollection<R> {
     fn bounds_of(&self, nth: usize) -> Rectangle;
     fn title_of(&self, nth: usize) -> &str;
     fn details_of(&self, nth: usize) -> &str;
+    fn value_of(&self, nth: usize) -> R;
     fn interact_with(&mut self, nth: usize) -> R;
     /// Whether an item is selectable. If not, the item will be skipped.
     fn selectable(&self, nth: usize) -> bool;
@@ -43,6 +44,11 @@ where
     fn bounds_of(&self, nth: usize) -> Rectangle {
         debug_assert!(nth == 0);
         self.bounds()
+    }
+
+    fn value_of(&self, nth: usize) -> R {
+        debug_assert!(nth == 0);
+        self.value_of()
     }
 
     fn interact_with(&mut self, nth: usize) -> R {
@@ -124,6 +130,10 @@ where
 {
     fn bounds_of(&self, nth: usize) -> Rectangle {
         self.items.as_ref()[nth].bounds()
+    }
+
+    fn value_of(&self, nth: usize) -> R {
+        self.items.as_ref()[nth].value_of()
     }
 
     fn interact_with(&mut self, nth: usize) -> R {
@@ -219,6 +229,10 @@ where
         self.object.bounds_of(nth)
     }
 
+    fn value_of(&self, nth: usize) -> R {
+        self.object.value_of(nth)
+    }
+
     fn interact_with(&mut self, nth: usize) -> R {
         self.object.interact_with(nth)
     }
@@ -267,6 +281,15 @@ where
             self.parent.bounds_of(nth)
         } else {
             self.object.bounds_of(nth - count)
+        }
+    }
+
+    fn value_of(&self, nth: usize) -> R {
+        let count = self.parent.count();
+        if nth < count {
+            self.parent.value_of(nth)
+        } else {
+            self.object.value_of(nth - count)
         }
     }
 

--- a/src/items/navigation_item.rs
+++ b/src/items/navigation_item.rs
@@ -40,6 +40,10 @@ where
     M: AsRef<str>,
     R: Copy,
 {
+    fn value_of(&self) -> R {
+        self.return_value
+    }
+
     fn interact(&mut self) -> R {
         self.return_value
     }

--- a/src/items/section_title.rs
+++ b/src/items/section_title.rs
@@ -28,6 +28,10 @@ where
     T: AsRef<str>,
     R: Default,
 {
+    fn value_of(&self) -> R {
+        R::default()
+    }
+
     fn interact(&mut self) -> R {
         R::default()
     }

--- a/src/items/select.rs
+++ b/src/items/select.rs
@@ -102,6 +102,10 @@ where
     D: AsRef<str>,
     S: SelectValue,
 {
+    fn value_of(&self) -> R {
+        (self.convert)(self.value)
+    }
+
     fn interact(&mut self) -> R {
         self.value = self.value.next();
         (self.convert)(self.value)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,8 @@ pub use embedded_menu_macros::{Menu, SelectValue};
 pub trait Marker {}
 
 pub trait MenuItem<R>: Marker + View {
+    /// Returns the value of the selected item, without interacting with it.
+    fn value_of(&self) -> R;
     fn interact(&mut self) -> R;
     fn set_style<C, S, IT, P>(&mut self, style: &MenuStyle<C, S, IT, P, R>)
     where
@@ -429,6 +431,21 @@ where
 
     pub fn state(&self) -> MenuState<IT::InputAdapter, P, S> {
         self.state
+    }
+}
+
+impl<T, IT, VG, R, C, P, S> Menu<T, IT, VG, R, C, P, S>
+where
+    T: AsRef<str>,
+    R: Copy,
+    IT: InputAdapterSource<R>,
+    VG: MenuItemCollection<R>,
+    C: PixelColor,
+    P: SelectionIndicatorController,
+    S: IndicatorStyle,
+{
+    pub fn selected_value(&self) -> R {
+        self.items.value_of(self.state.selected)
     }
 }
 


### PR DESCRIPTION
In my case, I need to show different UI outside the menu when selecting certain items. Unfortunately the label nor the marker can be used currently for this purpose, I need the return value (which is an enum with some index into an array).

This could also be used for managing the Details string, but I think that's out the scope of this PR.