### PR TITLE
Remove R from SectionTitle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Unreleased
  - Removed `MenuItem::value`
  - Removed `MenuItemCollection::title_of`
  - Removed `derive(Menu)`
+ - Removed the `R` type parameter from `SectionTitle`
 
 0.5.4 (2023-10-27)
 ==================

--- a/src/items/section_title.rs
+++ b/src/items/section_title.rs
@@ -12,28 +12,26 @@ use crate::{
     Marker, MenuItem, MenuStyle,
 };
 
-pub struct SectionTitle<T, R>
+pub struct SectionTitle<T>
 where
     T: AsRef<str>,
 {
     title_text: T,
     line: MenuLine,
-    _r: core::marker::PhantomData<R>,
 }
 
-impl<T, R> Marker for SectionTitle<T, R> where T: AsRef<str> {}
+impl<T> Marker for SectionTitle<T> where T: AsRef<str> {}
 
-impl<T, R> MenuItem<R> for SectionTitle<T, R>
+impl<T, R> MenuItem<R> for SectionTitle<T>
 where
     T: AsRef<str>,
-    R: Default,
 {
     fn value_of(&self) -> R {
-        R::default()
+        unreachable!("Selected a non-selectable menu item")
     }
 
     fn interact(&mut self) -> R {
-        R::default()
+        unreachable!("Selected a non-selectable menu item")
     }
 
     fn selectable(&self) -> bool {
@@ -67,7 +65,7 @@ where
     }
 }
 
-impl<T, R> SectionTitle<T, R>
+impl<T> SectionTitle<T>
 where
     T: AsRef<str>,
 {
@@ -75,12 +73,11 @@ where
         Self {
             title_text: title,
             line: MenuLine::empty(),
-            _r: core::marker::PhantomData,
         }
     }
 }
 
-impl<T, R> View for SectionTitle<T, R>
+impl<T> View for SectionTitle<T>
 where
     T: AsRef<str>,
 {


### PR DESCRIPTION
cc @hansl

We probably should have just done this in the first place. We don't __currently__ provide a way to access the value of arbitrary items, so normally this wouldn't panic, except:

 - if the Menu has only SectionTitle items
 - and the user manages to define the R type (e.g. manually ascribing it, or by letting the compiler infer something from usage)

I'm personally fine with making this change as I'm not sure how useful a menu is with no selectable items.