### PR TITLE
Initial pass of adding support for color displays

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,3 +56,10 @@ required-features = ["simulator"]
 [[example]]
 name = "small"
 required-features = ["simulator"]
+
+[[example]]
+name = "color"
+required-features = ["simulator"]
+
+[patch.crates-io]
+embedded-text = {path = "../embedded-text"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["embedded", "no-std"]
 [dependencies]
 embedded-graphics = "0.8.0"
 embedded-layout = "0.4.0"
-embedded-text = "0.6.0"
+embedded-text = "0.7"
 
 embedded-menu-macros = { version = "0.3.0", path = "embedded-menu-macros" }
 
@@ -60,6 +60,3 @@ required-features = ["simulator"]
 [[example]]
 name = "color"
 required-features = ["simulator"]
-
-[patch.crates-io]
-embedded-text = {path = "../embedded-text"}

--- a/examples/color.rs
+++ b/examples/color.rs
@@ -3,13 +3,13 @@
 //! Navigate using up/down arrows, interact using the Enter key
 
 use embedded_graphics::{
-    pixelcolor::{Rgb888, Rgb555},
+    pixelcolor::Rgb888,
     prelude::{DrawTargetExt, Point, Size},
     primitives::Rectangle,
     Drawable,
 };
 use embedded_graphics_simulator::{
-    BinaryColorTheme, OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent, Window,
+    OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent, Window,
 };
 use embedded_menu::{
     interaction::simulator::Simulator,
@@ -45,12 +45,10 @@ impl SelectValue for TestEnum {
 fn main() -> Result<(), core::convert::Infallible> {
     let mut menu = Menu::with_style(
         "Color Menu",
-        MenuStyle::new(Rgb888::new(51, 255, 51), Rgb555::new(255, 0, 0)).with_input_adapter(
-            Simulator {
-                page_size: 5,
-                esc_value: (),
-            },
-        ),
+        MenuStyle::new(Rgb888::new(51, 255, 51)).with_input_adapter(Simulator {
+            page_size: 5,
+            esc_value: (),
+        }),
     )
     .add_item(NavigationItem::new("Foo", ()).with_marker(">"))
     .add_item(Select::new("Check this", false))

--- a/examples/color.rs
+++ b/examples/color.rs
@@ -1,9 +1,9 @@
-//! Run using `cargo run --example small --target x86_64-pc-windows-msvc` --features=simulator
+//! Run using `cargo run --example color --target x86_64-pc-windows-msvc` --features=simulator
 //!
 //! Navigate using up/down arrows, interact using the Enter key
 
 use embedded_graphics::{
-    pixelcolor::BinaryColor,
+    pixelcolor::{Rgb888, Rgb555},
     prelude::{DrawTargetExt, Point, Size},
     primitives::Rectangle,
     Drawable,
@@ -44,11 +44,13 @@ impl SelectValue for TestEnum {
 
 fn main() -> Result<(), core::convert::Infallible> {
     let mut menu = Menu::with_style(
-        "Menu",
-        MenuStyle::default().with_input_adapter(Simulator {
-            page_size: 5,
-            esc_value: (),
-        }),
+        "Color Menu",
+        MenuStyle::new(Rgb888::new(51, 255, 51), Rgb555::new(255, 0, 0)).with_input_adapter(
+            Simulator {
+                page_size: 5,
+                esc_value: (),
+            },
+        ),
     )
     .add_item(NavigationItem::new("Foo", ()).with_marker(">"))
     .add_item(Select::new("Check this", false))
@@ -56,13 +58,11 @@ fn main() -> Result<(), core::convert::Infallible> {
     .add_item(Select::new("Check this too", false))
     .build();
 
-    let output_settings = OutputSettingsBuilder::new()
-        .theme(BinaryColorTheme::OledBlue)
-        .build();
-    let mut window = Window::new("Menu demonstration", &output_settings);
+    let output_settings = OutputSettingsBuilder::new().scale(4).build();
+    let mut window = Window::new("Menu demonstration w/color", &output_settings);
 
     'running: loop {
-        let mut display: SimulatorDisplay<BinaryColor> = SimulatorDisplay::new(Size::new(128, 64));
+        let mut display: SimulatorDisplay<Rgb888> = SimulatorDisplay::new(Size::new(128, 64));
         let mut sub = display.cropped(&Rectangle::new(Point::new(16, 16), Size::new(96, 34)));
         menu.update(&sub);
         menu.draw(&mut sub).unwrap();

--- a/examples/font.rs
+++ b/examples/font.rs
@@ -45,7 +45,7 @@ impl SelectValue for TestEnum {
 fn main() -> Result<(), core::convert::Infallible> {
     let mut menu = Menu::with_style(
         "Menu",
-        MenuStyle::new(BinaryColor::On)
+        MenuStyle::default()
             .with_font(&FONT_6X10)
             .with_title_font(&FONT_8X13_BOLD)
             .with_input_adapter(Simulator {

--- a/examples/owned.rs
+++ b/examples/owned.rs
@@ -46,7 +46,7 @@ fn main() -> Result<(), core::convert::Infallible> {
 
     let mut menu = Menu::with_style(
         format!("Items: {}", items.len()),
-        MenuStyle::new(BinaryColor::On).with_input_adapter(Simulator {
+        MenuStyle::default().with_input_adapter(Simulator {
             page_size: 5,
             esc_value: (),
         }),

--- a/examples/save_state.rs
+++ b/examples/save_state.rs
@@ -58,7 +58,7 @@ fn do_loop(
     data: &mut MenuData,
     item_count: usize,
 ) -> bool {
-    let style = MenuStyle::new(BinaryColor::On, BinaryColor::On)
+    let style = MenuStyle::new(BinaryColor::On)
         .with_input_adapter(Simulator {
             page_size: 5,
             esc_value: MenuEvent::Quit,

--- a/examples/save_state.rs
+++ b/examples/save_state.rs
@@ -58,7 +58,7 @@ fn do_loop(
     data: &mut MenuData,
     item_count: usize,
 ) -> bool {
-    let style = MenuStyle::new(BinaryColor::On)
+    let style = MenuStyle::new(BinaryColor::On, BinaryColor::On)
         .with_input_adapter(Simulator {
             page_size: 5,
             esc_value: MenuEvent::Quit,

--- a/examples/scrolling.rs
+++ b/examples/scrolling.rs
@@ -36,7 +36,7 @@ impl SelectValue for TestEnum {
 }
 
 fn main() -> Result<(), core::convert::Infallible> {
-    let style = MenuStyle::new(BinaryColor::On)
+    let style = MenuStyle::new(BinaryColor::On, BinaryColor::On)
         .with_input_adapter(Simulator {
             page_size: 5,
             esc_value: (),

--- a/examples/scrolling.rs
+++ b/examples/scrolling.rs
@@ -36,7 +36,7 @@ impl SelectValue for TestEnum {
 }
 
 fn main() -> Result<(), core::convert::Infallible> {
-    let style = MenuStyle::new(BinaryColor::On, BinaryColor::On)
+    let style = MenuStyle::new(BinaryColor::On)
         .with_input_adapter(Simulator {
             page_size: 5,
             esc_value: (),

--- a/examples/scrolling_single_touch.rs
+++ b/examples/scrolling_single_touch.rs
@@ -42,7 +42,7 @@ impl SelectValue for TestEnum {
 
 fn main() -> Result<(), core::convert::Infallible> {
     let style = MenuStyle::default()
-        .with_selection_indicator(AnimatedTriangle::new(160))
+        .with_selection_indicator(AnimatedTriangle::new(160, BinaryColor::On))
         .with_input_adapter(SingleTouch {
             ignore_time: 10,
             debounce_time: 1,

--- a/examples/scrolling_slice.rs
+++ b/examples/scrolling_slice.rs
@@ -36,7 +36,7 @@ impl SelectValue for TestEnum {
 }
 
 fn main() -> Result<(), core::convert::Infallible> {
-    let style = MenuStyle::new(BinaryColor::On)
+    let style = MenuStyle::default()
         .with_input_adapter(Simulator {
             page_size: 5,
             esc_value: (),

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -5,7 +5,7 @@ use crate::{
     Menu, MenuItem, MenuState, MenuStyle, NoItems,
 };
 use core::marker::PhantomData;
-use embedded_graphics::pixelcolor::PixelColor;
+use embedded_graphics::prelude::PixelColor;
 use embedded_layout::{
     layout::linear::LinearLayout,
     object_chain::ChainElement,
@@ -13,28 +13,28 @@ use embedded_layout::{
     view_group::{EmptyViewGroup, ViewGroup},
 };
 
-pub struct MenuBuilder<T, IT, LL, R, C, P, S>
+pub struct MenuBuilder<T, IT, LL, R, P, S, C>
 where
     T: AsRef<str>,
     IT: InputAdapterSource<R>,
-    C: PixelColor,
     S: IndicatorStyle,
     P: SelectionIndicatorController,
+    C: PixelColor,
 {
     title: T,
     items: LL,
-    style: MenuStyle<C, S, IT, P, R>,
+    style: MenuStyle<S, IT, P, R, C>,
 }
 
-impl<T, R, C, S, IT, P> MenuBuilder<T, IT, NoItems, R, C, P, S>
+impl<T, R, S, IT, P, C> MenuBuilder<T, IT, NoItems, R, P, S, C>
 where
     T: AsRef<str>,
-    C: PixelColor,
     S: IndicatorStyle,
     IT: InputAdapterSource<R>,
     P: SelectionIndicatorController,
+    C: PixelColor,
 {
-    pub const fn new(title: T, style: MenuStyle<C, S, IT, P, R>) -> Self {
+    pub const fn new(title: T, style: MenuStyle<S, IT, P, R, C>) -> Self {
         Self {
             title,
             items: NoItems,
@@ -43,15 +43,15 @@ where
     }
 }
 
-impl<T, IT, R, C, P, S> MenuBuilder<T, IT, NoItems, R, C, P, S>
+impl<T, IT, R, P, S, C> MenuBuilder<T, IT, NoItems, R, P, S, C>
 where
     T: AsRef<str>,
     IT: InputAdapterSource<R>,
-    C: PixelColor,
     P: SelectionIndicatorController,
     S: IndicatorStyle,
+    C: PixelColor + Default + 'static,
 {
-    pub fn add_item<I: MenuItem<R>>(self, mut item: I) -> MenuBuilder<T, IT, Chain<I>, R, C, P, S> {
+    pub fn add_item<I: MenuItem<R>>(self, mut item: I) -> MenuBuilder<T, IT, Chain<I>, R, P, S, C> {
         item.set_style(&self.style);
 
         MenuBuilder {
@@ -64,7 +64,7 @@ where
     pub fn add_items<I, IC>(
         self,
         mut items: IC,
-    ) -> MenuBuilder<T, IT, Chain<MenuItems<IC, I, R>>, R, C, P, S>
+    ) -> MenuBuilder<T, IT, Chain<MenuItems<IC, I, R>>, R, P, S, C>
     where
         I: MenuItem<R>,
         IC: AsRef<[I]> + AsMut<[I]>,
@@ -82,19 +82,19 @@ where
     }
 }
 
-impl<T, IT, CE, R, C, P, S> MenuBuilder<T, IT, Chain<CE>, R, C, P, S>
+impl<T, IT, CE, R, P, S, C> MenuBuilder<T, IT, Chain<CE>, R, P, S, C>
 where
     T: AsRef<str>,
     IT: InputAdapterSource<R>,
     Chain<CE>: MenuItemCollection<R>,
-    C: PixelColor,
     P: SelectionIndicatorController,
     S: IndicatorStyle,
+    C: PixelColor + Default + 'static,
 {
     pub fn add_item<I: MenuItem<R>>(
         self,
         mut item: I,
-    ) -> MenuBuilder<T, IT, Link<I, Chain<CE>>, R, C, P, S> {
+    ) -> MenuBuilder<T, IT, Link<I, Chain<CE>>, R, P, S, C> {
         item.set_style(&self.style);
 
         MenuBuilder {
@@ -107,7 +107,7 @@ where
     pub fn add_items<I, IC>(
         self,
         mut items: IC,
-    ) -> MenuBuilder<T, IT, Link<MenuItems<IC, I, R>, Chain<CE>>, R, C, P, S>
+    ) -> MenuBuilder<T, IT, Link<MenuItems<IC, I, R>, Chain<CE>>, R, P, S, C>
     where
         I: MenuItem<R>,
         IC: AsRef<[I]> + AsMut<[I]>,
@@ -125,20 +125,20 @@ where
     }
 }
 
-impl<T, IT, I, CE, R, C, P, S> MenuBuilder<T, IT, Link<I, CE>, R, C, P, S>
+impl<T, IT, I, CE, R, P, S, C> MenuBuilder<T, IT, Link<I, CE>, R, P, S, C>
 where
     T: AsRef<str>,
     IT: InputAdapterSource<R>,
     Link<I, CE>: MenuItemCollection<R> + ChainElement,
     CE: MenuItemCollection<R> + ChainElement,
-    C: PixelColor,
     P: SelectionIndicatorController,
     S: IndicatorStyle,
+    C: PixelColor + Default + 'static,
 {
     pub fn add_item<I2: MenuItem<R>>(
         self,
         mut item: I2,
-    ) -> MenuBuilder<T, IT, Link<I2, Link<I, CE>>, R, C, P, S> {
+    ) -> MenuBuilder<T, IT, Link<I2, Link<I, CE>>, R, P, S, C> {
         item.set_style(&self.style);
 
         MenuBuilder {
@@ -151,7 +151,7 @@ where
     pub fn add_items<I2, IC>(
         self,
         mut items: IC,
-    ) -> MenuBuilder<T, IT, Link<MenuItems<IC, I2, R>, Link<I, CE>>, R, C, P, S>
+    ) -> MenuBuilder<T, IT, Link<MenuItems<IC, I2, R>, Link<I, CE>>, R, P, S, C>
     where
         I2: MenuItem<R>,
         IC: AsRef<[I2]> + AsMut<[I2]>,
@@ -169,14 +169,14 @@ where
     }
 }
 
-impl<T, IT, VG, R, C, P, S> MenuBuilder<T, IT, VG, R, C, P, S>
+impl<T, IT, VG, R, P, S, C> MenuBuilder<T, IT, VG, R, P, S, C>
 where
     T: AsRef<str>,
     IT: InputAdapterSource<R>,
     VG: ViewGroup + MenuItemCollection<R>,
-    C: PixelColor,
     P: SelectionIndicatorController,
     S: IndicatorStyle,
+    C: PixelColor,
 {
     pub fn build(self) -> Menu<T, IT, VG, R, C, P, S> {
         self.build_with_state(MenuState {
@@ -191,7 +191,7 @@ where
     pub fn build_with_state(
         mut self,
         mut state: MenuState<IT::InputAdapter, P, S>,
-    ) -> Menu<T, IT, VG, R, C, P, S> {
+    ) -> Menu<T, IT, VG, R, P, S, C> {
         // We have less menu items than before. Avoid crashing.
         let max_idx = self.items.count().saturating_sub(1);
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -178,7 +178,7 @@ where
     S: IndicatorStyle,
     C: PixelColor,
 {
-    pub fn build(self) -> Menu<T, IT, VG, R, C, P, S> {
+    pub fn build(self) -> Menu<T, IT, VG, R, P, S, C> {
         self.build_with_state(MenuState {
             selected: 0,
             list_offset: 0,

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -1,7 +1,6 @@
 use core::marker::PhantomData;
 
 use embedded_graphics::{
-    pixelcolor::Rgb888,
     prelude::{DrawTarget, PixelColor, Point, Size},
     primitives::Rectangle,
 };
@@ -21,17 +20,17 @@ pub trait MenuItemCollection<R> {
     /// Whether an item is selectable. If not, the item will be skipped.
     fn selectable(&self, nth: usize) -> bool;
     fn count(&self) -> usize;
-    fn draw_styled<C, S, IT, P, DIS>(
+    fn draw_styled<C, S, IT, P, D>(
         &self,
-        style: &MenuStyle<C, S, IT, P, R>,
-        display: &mut DIS,
-    ) -> Result<(), DIS::Error>
+        style: &MenuStyle<S, IT, P, R, C>,
+        display: &mut D,
+    ) -> Result<(), D::Error>
     where
-        C: PixelColor + From<Rgb888>,
         S: IndicatorStyle,
         IT: InputAdapterSource<R>,
         P: SelectionIndicatorController,
-        DIS: DrawTarget<Color = C>;
+        D: DrawTarget<Color = C>,
+        C: PixelColor + Default + 'static;
 }
 
 // Treat any MenuItem impl as a 1-element collection
@@ -65,15 +64,15 @@ where
 
     fn draw_styled<C, S, IT, P, DIS>(
         &self,
-        style: &MenuStyle<C, S, IT, P, R>,
+        style: &MenuStyle<S, IT, P, R, C>,
         display: &mut DIS,
     ) -> Result<(), DIS::Error>
     where
-        C: PixelColor + From<Rgb888>,
         S: IndicatorStyle,
         IT: InputAdapterSource<R>,
         P: SelectionIndicatorController,
         DIS: DrawTarget<Color = C>,
+        C: PixelColor + Default + 'static,
     {
         MenuItem::draw_styled(self, style, display)
     }
@@ -136,17 +135,17 @@ where
         self.items.as_ref().len()
     }
 
-    fn draw_styled<PC, S, IT, P, DIS>(
+    fn draw_styled<MSC, S, IT, P, D>(
         &self,
-        style: &MenuStyle<PC, S, IT, P, R>,
-        display: &mut DIS,
-    ) -> Result<(), DIS::Error>
+        style: &MenuStyle<S, IT, P, R, MSC>,
+        display: &mut D,
+    ) -> Result<(), D::Error>
     where
-        PC: PixelColor + From<Rgb888>,
         S: IndicatorStyle,
         IT: InputAdapterSource<R>,
         P: SelectionIndicatorController,
-        DIS: DrawTarget<Color = PC>,
+        D: DrawTarget<Color = MSC>,
+        MSC: PixelColor + Default + 'static,
     {
         for item in self.items.as_ref() {
             item.draw_styled(style, display)?;
@@ -225,18 +224,17 @@ where
         self.object.count()
     }
 
-    fn draw_styled<PC, S, IT, P, DIS>(
+    fn draw_styled<C, S, IT, P, D>(
         &self,
-        style: &MenuStyle<PC, S, IT, P, R>,
-        display: &mut DIS,
-    ) -> Result<(), DIS::Error>
+        style: &MenuStyle<S, IT, P, R, C>,
+        display: &mut D,
+    ) -> Result<(), D::Error>
     where
-        PC: PixelColor + From<Rgb888>,
         S: IndicatorStyle,
         IT: InputAdapterSource<R>,
         P: SelectionIndicatorController,
-
-        DIS: DrawTarget<Color = PC>,
+        D: DrawTarget<Color = C>,
+        C: PixelColor + Default + 'static,
     {
         self.object.draw_styled(style, display)
     }
@@ -287,18 +285,17 @@ where
         self.object.count() + self.parent.count()
     }
 
-    fn draw_styled<PC, S, IT, P, DIS>(
+    fn draw_styled<C, S, IT, P, D>(
         &self,
-        style: &MenuStyle<PC, S, IT, P, R>,
-        display: &mut DIS,
-    ) -> Result<(), DIS::Error>
+        style: &MenuStyle<S, IT, P, R, C>,
+        display: &mut D,
+    ) -> Result<(), D::Error>
     where
-        PC: PixelColor + From<Rgb888>,
         S: IndicatorStyle,
         IT: InputAdapterSource<R>,
         P: SelectionIndicatorController,
-
-        DIS: DrawTarget<Color = PC>,
+        D: DrawTarget<Color = C>,
+        C: PixelColor + Default + 'static,
     {
         self.parent.draw_styled(style, display)?;
         self.object.draw_styled(style, display)?;

--- a/src/items/mod.rs
+++ b/src/items/mod.rs
@@ -13,7 +13,6 @@ use crate::{
 };
 use embedded_graphics::{
     draw_target::DrawTarget,
-    pixelcolor::Rgb888,
     prelude::{PixelColor, Point, Size},
     primitives::Rectangle,
     text::{renderer::TextRenderer, Baseline},
@@ -28,12 +27,12 @@ pub struct MenuLine {
 }
 
 impl MenuLine {
-    pub fn new<C, S, IT, P, R>(longest_value: &str, style: &MenuStyle<C, S, IT, P, R>) -> Self
+    pub fn new<C, S, IT, P, R>(longest_value: &str, style: &MenuStyle<S, IT, P, R, C>) -> Self
     where
-        C: PixelColor,
         S: IndicatorStyle,
         IT: InputAdapterSource<R>,
         P: SelectionIndicatorController,
+        C: PixelColor,
     {
         let style = style.text_style();
 
@@ -59,19 +58,19 @@ impl MenuLine {
         }
     }
 
-    pub fn draw_styled<D, C, S, IT, P, R>(
+    pub fn draw_styled<C, D, S, IT, P, R>(
         &self,
         title: &str,
         value_text: &str,
-        style: &MenuStyle<C, S, IT, P, R>,
+        style: &MenuStyle<S, IT, P, R, C>,
         display: &mut D,
     ) -> Result<(), D::Error>
     where
         D: DrawTarget<Color = C>,
-        C: PixelColor + From<Rgb888>,
         S: IndicatorStyle,
         IT: InputAdapterSource<R>,
         P: SelectionIndicatorController,
+        C: PixelColor + Default + 'static,
     {
         let display_area = display.bounding_box();
 

--- a/src/items/navigation_item.rs
+++ b/src/items/navigation_item.rs
@@ -1,5 +1,4 @@
 use embedded_graphics::{
-    pixelcolor::Rgb888,
     prelude::{DrawTarget, PixelColor, Point},
     primitives::Rectangle,
 };
@@ -44,27 +43,27 @@ where
         self.return_value
     }
 
-    fn set_style<C, S, IT, P>(&mut self, style: &MenuStyle<C, S, IT, P, R>)
+    fn set_style<S, IT, P, C>(&mut self, style: &MenuStyle<S, IT, P, R, C>)
     where
-        C: PixelColor,
         S: IndicatorStyle,
         IT: InputAdapterSource<R>,
         P: SelectionIndicatorController,
+        C: PixelColor + Default + 'static,
     {
         self.line = MenuLine::new(self.marker.as_ref(), style);
     }
 
-    fn draw_styled<C, S, IT, P, DIS>(
+    fn draw_styled<S, IT, P, DIS, C>(
         &self,
-        style: &MenuStyle<C, S, IT, P, R>,
+        style: &MenuStyle<S, IT, P, R, C>,
         display: &mut DIS,
     ) -> Result<(), DIS::Error>
     where
-        C: PixelColor + From<Rgb888>,
         S: IndicatorStyle,
         IT: InputAdapterSource<R>,
         P: SelectionIndicatorController,
         DIS: DrawTarget<Color = C>,
+        C: PixelColor + Default + 'static,
     {
         self.line.draw_styled(
             self.title_text.as_ref(),

--- a/src/items/section_title.rs
+++ b/src/items/section_title.rs
@@ -1,5 +1,4 @@
 use embedded_graphics::{
-    pixelcolor::Rgb888,
     prelude::{DrawTarget, PixelColor, Point},
     primitives::Rectangle,
 };
@@ -40,27 +39,27 @@ where
         false
     }
 
-    fn set_style<C, S, IT, P>(&mut self, style: &MenuStyle<C, S, IT, P, R>)
+    fn set_style<S, IT, P, C>(&mut self, style: &MenuStyle<S, IT, P, R, C>)
     where
-        C: PixelColor,
         S: IndicatorStyle,
         IT: InputAdapterSource<R>,
         P: SelectionIndicatorController,
+        C: PixelColor,
     {
         self.line = MenuLine::new("", style);
     }
 
-    fn draw_styled<C, S, IT, P, DIS>(
+    fn draw_styled<S, IT, P, D, C>(
         &self,
-        style: &MenuStyle<C, S, IT, P, R>,
-        display: &mut DIS,
-    ) -> Result<(), DIS::Error>
+        style: &MenuStyle<S, IT, P, R, C>,
+        display: &mut D,
+    ) -> Result<(), D::Error>
     where
-        C: PixelColor + From<Rgb888>,
         S: IndicatorStyle,
         IT: InputAdapterSource<R>,
         P: SelectionIndicatorController,
-        DIS: DrawTarget<Color = C>,
+        D: DrawTarget<Color = C>,
+        C: PixelColor + Default + 'static,
     {
         self.line
             .draw_styled(self.title_text.as_ref(), "", style, display)

--- a/src/items/select.rs
+++ b/src/items/select.rs
@@ -1,5 +1,4 @@
 use embedded_graphics::{
-    pixelcolor::Rgb888,
     prelude::{DrawTarget, PixelColor, Point},
     primitives::Rectangle,
 };
@@ -94,12 +93,12 @@ where
         (self.convert)(self.value)
     }
 
-    fn set_style<C, ST, IT, P>(&mut self, style: &MenuStyle<C, ST, IT, P, R>)
+    fn set_style<ST, IT, P, C>(&mut self, style: &MenuStyle<ST, IT, P, R, C>)
     where
-        C: PixelColor,
         ST: IndicatorStyle,
         IT: InputAdapterSource<R>,
         P: SelectionIndicatorController,
+        C: PixelColor,
     {
         let initial = self.value;
         let mut longest_str = initial.name();
@@ -115,17 +114,17 @@ where
         self.line = MenuLine::new(longest_str, style);
     }
 
-    fn draw_styled<C, ST, IT, P, DIS>(
+    fn draw_styled<IS, IT, P, DIS, C>(
         &self,
-        style: &MenuStyle<C, ST, IT, P, R>,
+        style: &MenuStyle<IS, IT, P, R, C>,
         display: &mut DIS,
     ) -> Result<(), DIS::Error>
     where
-        C: PixelColor + From<Rgb888>,
-        ST: IndicatorStyle,
+        IS: IndicatorStyle,
         IT: InputAdapterSource<R>,
         P: SelectionIndicatorController,
         DIS: DrawTarget<Color = C>,
+        C: PixelColor + Default + 'static,
     {
         self.line
             .draw_styled(self.title_text.as_ref(), self.value.name(), style, display)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ use embedded_graphics::{
     draw_target::DrawTarget,
     geometry::{AnchorPoint, AnchorX, AnchorY},
     mono_font::{ascii::FONT_6X10, MonoFont, MonoTextStyle},
-    pixelcolor::{BinaryColor, PixelColor, Rgb888},
+    pixelcolor::{BinaryColor, PixelColor},
     prelude::{Dimensions, DrawTargetExt, Point},
     primitives::{Line, Primitive, PrimitiveStyle},
     Drawable,
@@ -48,26 +48,26 @@ pub trait MenuItem<R>: Marker + View {
     /// Returns the value of the selected item, without interacting with it.
     fn value_of(&self) -> R;
     fn interact(&mut self) -> R;
-    fn set_style<C, S, IT, P>(&mut self, style: &MenuStyle<C, S, IT, P, R>)
+    fn set_style<S, IT, P, C>(&mut self, style: &MenuStyle<S, IT, P, R, C>)
     where
-        C: PixelColor,
-        S: IndicatorStyle,
-        IT: InputAdapterSource<R>,
-        P: SelectionIndicatorController;
-    fn selectable(&self) -> bool {
-        true
-    }
-    fn draw_styled<C, S, IT, P, DIS>(
-        &self,
-        style: &MenuStyle<C, S, IT, P, R>,
-        display: &mut DIS,
-    ) -> Result<(), DIS::Error>
-    where
-        C: PixelColor + From<Rgb888>,
         S: IndicatorStyle,
         IT: InputAdapterSource<R>,
         P: SelectionIndicatorController,
-        DIS: DrawTarget<Color = C>;
+        C: PixelColor + Default + 'static;
+    fn selectable(&self) -> bool {
+        true
+    }
+    fn draw_styled<S, IT, P, D, C>(
+        &self,
+        style: &MenuStyle<S, IT, P, R, C>,
+        display: &mut D,
+    ) -> Result<(), D::Error>
+    where
+        S: IndicatorStyle,
+        IT: InputAdapterSource<R>,
+        P: SelectionIndicatorController,
+        D: DrawTarget<Color = C>,
+        C: PixelColor + Default + 'static;
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -78,12 +78,12 @@ pub enum DisplayScrollbar {
 }
 
 #[derive(Copy, Clone, Debug)]
-pub struct MenuStyle<C, S, IT, P, R>
+pub struct MenuStyle<S, IT, P, R, C>
 where
-    C: PixelColor,
     S: IndicatorStyle,
     IT: InputAdapterSource<R>,
     P: SelectionIndicatorController,
+    C: PixelColor,
 {
     pub(crate) color: C,
     pub(crate) scrollbar: DisplayScrollbar,
@@ -94,25 +94,28 @@ where
     _marker: PhantomData<R>,
 }
 
-impl<R> Default for MenuStyle<BinaryColor, LineIndicator, Programmed, StaticPosition, R> {
+impl<R> Default
+    for MenuStyle<LineIndicator<BinaryColor>, Programmed, StaticPosition, R, BinaryColor>
+{
     fn default() -> Self {
-        Self::new(BinaryColor::On)
+        Self::new(BinaryColor::On, BinaryColor::On)
     }
 }
 
-impl<C, R> MenuStyle<C, LineIndicator, Programmed, StaticPosition, R>
+impl<IC, MC, R> MenuStyle<LineIndicator<IC>, Programmed, StaticPosition, R, MC>
 where
-    C: PixelColor,
+    IC: PixelColor,
+    MC: PixelColor,
 {
-    pub const fn new(color: C) -> Self {
+    pub const fn new(menu_color: MC, indicator_color: IC) -> Self {
         Self {
-            color,
+            color: menu_color,
             scrollbar: DisplayScrollbar::Auto,
             font: &FONT_6X10,
             title_font: &FONT_6X10,
             input_adapter: Programmed,
             indicator: Indicator {
-                style: LineIndicator,
+                style: LineIndicator::new(indicator_color),
                 controller: StaticPosition,
             },
             _marker: PhantomData,
@@ -120,12 +123,12 @@ where
     }
 }
 
-impl<C, S, IT, P, R> MenuStyle<C, S, IT, P, R>
+impl<S, IT, P, R, C> MenuStyle<S, IT, P, R, C>
 where
-    C: PixelColor,
     S: IndicatorStyle,
     IT: InputAdapterSource<R>,
     P: SelectionIndicatorController,
+    C: PixelColor,
 {
     pub const fn with_font(self, font: &'static MonoFont<'static>) -> Self {
         Self { font, ..self }
@@ -142,7 +145,7 @@ where
     pub const fn with_selection_indicator<S2>(
         self,
         indicator_style: S2,
-    ) -> MenuStyle<C, S2, IT, P, R>
+    ) -> MenuStyle<S2, IT, P, R, C>
     where
         S2: IndicatorStyle,
     {
@@ -160,13 +163,13 @@ where
         }
     }
 
-    pub const fn with_input_adapter<IT2>(self, input_adapter: IT2) -> MenuStyle<C, S, IT2, P, R>
+    pub const fn with_input_adapter<IT2>(self, input_adapter: IT2) -> MenuStyle<S, IT2, P, R, C>
     where
         IT2: InputAdapterSource<R>,
     {
         MenuStyle {
-            input_adapter,
             color: self.color,
+            input_adapter,
             scrollbar: self.scrollbar,
             font: self.font,
             title_font: self.title_font,
@@ -178,10 +181,10 @@ where
     pub const fn with_animated_selection_indicator(
         self,
         frames: i32,
-    ) -> MenuStyle<C, S, IT, AnimatedPosition, R> {
+    ) -> MenuStyle<S, IT, AnimatedPosition, R, C> {
         MenuStyle {
-            input_adapter: self.input_adapter,
             color: self.color,
+            input_adapter: self.input_adapter,
             scrollbar: self.scrollbar,
             font: self.font,
             title_font: self.title_font,
@@ -267,7 +270,7 @@ where
         &mut self,
         selected: usize,
         items: &impl MenuItemCollection<R>,
-        style: &MenuStyle<C, S, ITS, P, R>,
+        style: &MenuStyle<S, ITS, P, R, C>,
     ) where
         ITS: InputAdapterSource<R, InputAdapter = IT>,
         C: PixelColor,
@@ -285,59 +288,59 @@ where
     }
 }
 
-pub struct Menu<T, IT, VG, R, C, P, S>
+pub struct Menu<T, IT, VG, R, P, S, C>
 where
     T: AsRef<str>,
     IT: InputAdapterSource<R>,
-    C: PixelColor,
     P: SelectionIndicatorController,
     S: IndicatorStyle,
+    C: PixelColor,
 {
     _return_type: PhantomData<R>,
     title: T,
     items: VG,
-    style: MenuStyle<C, S, IT, P, R>,
+    style: MenuStyle<S, IT, P, R, C>,
     state: MenuState<IT::InputAdapter, P, S>,
 }
 
-impl<T, R, C, S> Menu<T, Programmed, NoItems, R, C, StaticPosition, S>
+impl<T, R, S, C> Menu<T, Programmed, NoItems, R, StaticPosition, S, C>
 where
     T: AsRef<str>,
-    C: PixelColor,
     S: IndicatorStyle,
+    C: PixelColor,
 {
-    pub fn new(title: T) -> MenuBuilder<T, Programmed, NoItems, R, C, StaticPosition, S>
+    pub fn new(title: T) -> MenuBuilder<T, Programmed, NoItems, R, StaticPosition, S, C>
     where
-        MenuStyle<C, S, Programmed, StaticPosition, R>: Default,
+        MenuStyle<S, Programmed, StaticPosition, R, C>: Default,
     {
         Self::with_style(title, MenuStyle::default())
     }
 }
 
-impl<T, IT, R, C, P, S> Menu<T, IT, NoItems, R, C, P, S>
+impl<T, IT, R, P, S, C> Menu<T, IT, NoItems, R, P, S, C>
 where
     T: AsRef<str>,
-    C: PixelColor,
     S: IndicatorStyle,
     IT: InputAdapterSource<R>,
     P: SelectionIndicatorController,
+    C: PixelColor,
 {
     pub fn with_style(
         title: T,
-        style: MenuStyle<C, S, IT, P, R>,
-    ) -> MenuBuilder<T, IT, NoItems, R, C, P, S> {
+        style: MenuStyle<S, IT, P, R, C>,
+    ) -> MenuBuilder<T, IT, NoItems, R, P, S, C> {
         MenuBuilder::new(title, style)
     }
 }
 
-impl<T, IT, VG, R, C, P, S> Menu<T, IT, VG, R, C, P, S>
+impl<T, IT, VG, R, P, S, C> Menu<T, IT, VG, R, P, S, C>
 where
     T: AsRef<str>,
     IT: InputAdapterSource<R>,
     VG: MenuItemCollection<R>,
-    C: PixelColor,
     P: SelectionIndicatorController,
     S: IndicatorStyle,
+    C: PixelColor,
 {
     pub fn interact(&mut self, input: <IT::InputAdapter as InputAdapter>::Input) -> Option<R> {
         let input = self
@@ -380,7 +383,7 @@ where
     }
 }
 
-impl<T, IT, VG, R, C, P, S> Menu<T, IT, VG, R, C, P, S>
+impl<T, IT, VG, R, P, S, C> Menu<T, IT, VG, R, P, S, C>
 where
     T: AsRef<str>,
     R: Copy,
@@ -395,14 +398,15 @@ where
     }
 }
 
-impl<T, IT, VG, R, C, P, S> Menu<T, IT, VG, R, C, P, S>
+impl<T, IT, VG, R, C, P, S> Menu<T, IT, VG, R, P, S, C>
 where
     T: AsRef<str>,
     IT: InputAdapterSource<R>,
     VG: ViewGroup + MenuItemCollection<R>,
-    C: PixelColor + From<Rgb888>,
     P: SelectionIndicatorController,
     S: IndicatorStyle,
+    C: PixelColor + Default + 'static,
+    <S as IndicatorStyle>::Color: Into<C>,
 {
     fn header<'t>(
         &self,
@@ -410,7 +414,8 @@ where
         display: &impl Dimensions,
     ) -> Option<impl View + 't + Drawable<Color = C>>
     where
-        C: 't,
+        <S as IndicatorStyle>::Color: PixelColor,
+        C: PixelColor + Default + 'static,
     {
         if title.is_empty() {
             return None;
@@ -484,20 +489,23 @@ where
     }
 }
 
-impl<T, IT, VG, R, P, S> Drawable for Menu<T, IT, VG, R, BinaryColor, P, S>
+impl<T, IT, VG, R, C, P, S> Drawable for Menu<T, IT, VG, R, P, S, C>
 where
     T: AsRef<str>,
     IT: InputAdapterSource<R>,
     VG: ViewGroup + MenuItemCollection<R>,
     P: SelectionIndicatorController,
     S: IndicatorStyle,
+    <S as IndicatorStyle>::Color: Into<C>,
+    C: PixelColor + Default + 'static,
 {
     type Color = BinaryColor;
     type Output = ();
 
     fn draw<D>(&self, display: &mut D) -> Result<(), D::Error>
     where
-        D: DrawTarget<Color = BinaryColor>,
+        D: DrawTarget<Color = C>,
+        <S as IndicatorStyle>::Color: Into<C>,
     {
         let display_area = display.bounding_box();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,24 +98,23 @@ impl<R> Default
     for MenuStyle<LineIndicator<BinaryColor>, Programmed, StaticPosition, R, BinaryColor>
 {
     fn default() -> Self {
-        Self::new(BinaryColor::On, BinaryColor::On)
+        Self::new(BinaryColor::On)
     }
 }
 
-impl<IC, MC, R> MenuStyle<LineIndicator<IC>, Programmed, StaticPosition, R, MC>
+impl<C, R> MenuStyle<LineIndicator<C>, Programmed, StaticPosition, R, C>
 where
-    IC: PixelColor,
-    MC: PixelColor,
+    C: PixelColor,
 {
-    pub const fn new(menu_color: MC, indicator_color: IC) -> Self {
+    pub const fn new(color: C) -> Self {
         Self {
-            color: menu_color,
+            color,
             scrollbar: DisplayScrollbar::Auto,
             font: &FONT_6X10,
             title_font: &FONT_6X10,
             input_adapter: Programmed,
             indicator: Indicator {
-                style: LineIndicator::new(indicator_color),
+                style: LineIndicator::new(color),
                 controller: StaticPosition,
             },
             _marker: PhantomData,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -498,7 +498,7 @@ where
     <S as IndicatorStyle>::Color: Into<C>,
     C: PixelColor + Default + 'static,
 {
-    type Color = BinaryColor;
+    type Color = C;
     type Output = ();
 
     fn draw<D>(&self, display: &mut D) -> Result<(), D::Error>

--- a/src/selection_indicator/style/invert.rs
+++ b/src/selection_indicator/style/invert.rs
@@ -28,6 +28,10 @@ impl IndicatorStyle for Invert {
         Rectangle::new(bounds.top_left, Size::new(fill_width, bounds.size.height))
     }
 
+    fn color(&self, state: &Self::State) -> Self::Color {
+        unimplemented!()
+    }
+
     fn draw<D>(
         &self,
         state: &Self::State,

--- a/src/selection_indicator/style/line.rs
+++ b/src/selection_indicator/style/line.rs
@@ -1,6 +1,6 @@
 use embedded_graphics::{
     pixelcolor::BinaryColor,
-    prelude::{DrawTarget, Size},
+    prelude::{DrawTarget, PixelColor, Size},
     primitives::{Primitive, PrimitiveStyle, Rectangle},
     Drawable,
 };
@@ -14,11 +14,23 @@ use crate::{
 };
 
 #[derive(Clone, Copy)]
-pub struct Line;
+pub struct Line<C = BinaryColor> {
+    color: C,
+}
 
-impl IndicatorStyle for Line {
+impl<C> Line<C> {
+    pub const fn new(color: C) -> Self {
+        Self { color }
+    }
+}
+
+impl<C> IndicatorStyle for Line<C>
+where
+    C: Copy + PixelColor,
+{
     type Shape = Rectangle;
     type State = ();
+    type Color = C;
 
     fn padding(&self, _state: &Self::State, _height: i32) -> Insets {
         Insets {
@@ -36,6 +48,10 @@ impl IndicatorStyle for Line {
         )
     }
 
+    fn color(&self, _state: &Self::State) -> Self::Color {
+        self.color
+    }
+
     fn draw<D>(
         &self,
         state: &Self::State,
@@ -43,7 +59,7 @@ impl IndicatorStyle for Line {
         display: &mut D,
     ) -> Result<Self::Shape, D::Error>
     where
-        D: DrawTarget<Color = BinaryColor>,
+        D: DrawTarget<Color = Self::Color>,
     {
         let display_area = display.bounding_box();
 
@@ -56,7 +72,7 @@ impl IndicatorStyle for Line {
         let shape = self.shape(state, display_area, fill_width);
 
         shape
-            .into_styled(PrimitiveStyle::with_fill(BinaryColor::On))
+            .into_styled(PrimitiveStyle::with_fill(self.color(state)))
             .draw(display)?;
 
         Ok(shape)

--- a/src/selection_indicator/style/mod.rs
+++ b/src/selection_indicator/style/mod.rs
@@ -1,6 +1,5 @@
 use embedded_graphics::{
-    pixelcolor::BinaryColor,
-    prelude::DrawTarget,
+    prelude::{DrawTarget, PixelColor},
     primitives::{ContainsPoint, Rectangle},
     transform::Transform,
 };
@@ -9,14 +8,14 @@ use crate::{interaction::InputState, selection_indicator::Insets};
 
 pub mod animated_triangle;
 pub mod border;
-pub mod invert;
+// pub mod invert;
 pub mod line;
 pub mod triangle;
 
 // Re-export the styles themselves to make them easier to use.
 pub use animated_triangle::AnimatedTriangle;
 pub use border::Border;
-pub use invert::Invert;
+// pub use invert::Invert;
 pub use line::Line;
 pub use triangle::Triangle;
 
@@ -37,11 +36,13 @@ pub fn interpolate(value: u32, x_min: u32, x_max: u32, y_min: u32, y_max: u32) -
 pub trait IndicatorStyle: Clone + Copy {
     type Shape: ContainsPoint + Transform + Clone;
     type State: Default + Copy;
+    type Color: PixelColor;
 
     fn on_target_changed(&self, _state: &mut Self::State) {}
     fn update(&self, _state: &mut Self::State, _input_state: InputState) {}
     fn padding(&self, state: &Self::State, height: i32) -> Insets;
     fn shape(&self, state: &Self::State, bounds: Rectangle, fill_width: u32) -> Self::Shape;
+    fn color(&self, state: &Self::State) -> Self::Color;
     fn draw<D>(
         &self,
         state: &Self::State,
@@ -49,7 +50,7 @@ pub trait IndicatorStyle: Clone + Copy {
         display: &mut D,
     ) -> Result<Self::Shape, D::Error>
     where
-        D: DrawTarget<Color = BinaryColor>;
+        D: DrawTarget<Color = Self::Color>;
 }
 
 #[test]

--- a/src/selection_indicator/style/rectangle.rs
+++ b/src/selection_indicator/style/rectangle.rs
@@ -1,0 +1,65 @@
+use embedded_graphics::{
+    prelude::{DrawTarget, Point, Size},
+    primitives::{ContainsPoint, Primitive, PrimitiveStyle, Rectangle as RectangleShape},
+    transform::Transform,
+    Drawable,
+};
+use embedded_layout::prelude::{horizontal::LeftToRight, vertical::Center, Align};
+
+use crate::{
+    interaction::InputState,
+    selection_indicator::{
+        style::{interpolate, IndicatorStyle},
+        Insets,
+    },
+};
+
+#[derive(Clone, Copy)]
+pub struct Rectangle<C = BinaryColor> {
+    color: C,
+}
+
+impl<C> IndicatorStyle for Rectangle<C> 
+where C: Copy
+{
+    type Shape = Arrow<C>;
+    type State = ();
+
+    fn padding(&self, _state: &Self::State, height: i32) -> Insets {
+        Insets {
+            left: height / 2 + 1,
+            top: 0,
+            right: 0,
+            bottom: 0,
+        }
+    }
+
+    fn shape(&self, _state: &Self::State, bounds: RectangleShape, fill_width: u32) -> Self::Shape {
+        Arrow::new(bounds, fill_width, self.color)
+    }
+
+    fn draw<D>(
+        &self,
+        state: &Self::State,
+        input_state: InputState,
+        display: &mut D,
+    ) -> Result<Self::Shape, D::Error>
+    where
+        D: DrawTarget,
+        <D as DrawTarget>::Color: From<<Self::Shape as Drawable>::Color>,
+    {
+        let display_area = display.bounding_box();
+
+        let fill_width = if let InputState::InProgress(progress) = input_state {
+            interpolate(progress as u32, 0, 255, 0, display_area.size.width)
+        } else {
+            0
+        };
+
+        let shape = self.shape(state, display_area, fill_width);
+
+        shape.draw(display)?;
+
+        Ok(shape)
+    }
+}


### PR DESCRIPTION
This PR is meant as a first-pass at adding support for color displays, including a new `color.rs` example illustrating basic color support for the menu items and indicator. All other examples should continue to work as-is and existing code should continue to work with minimal to no modifications. 

Currently, the macros have not been updated and are broken within this branch. Updating these felt like a significant lift and it was noticed that there is a mention of removing macros withing the [0.6 planning issue](https://github.com/bugadani/embedded-menu/issues/36). There is also a bit of commented out code related to the inversion selector - given that "inversion" is not a universally support operation within all color palettes, and there is no existing trait (afaik) to support this operation. 

This is very light in terms of features for color support, but aims to be more of a stepping stone to adding richer color menus. At this point I am mostly curious to collect feedback

note: this PR currently includes a patch to a local copy of `embedded-text` utilizing a recent and unreleased change to avoid propagation of `From<Rgb888>` trait bounds - this obviously would be removed before any potential merge