### PR TITLE
Make MenuListItem object-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Unreleased
  - `SelectValue::marker` can now return values with non-`'static` lifetimes
  - `SelectValue` now requires `Clone` instead of `Copy`
  - `SelectValue::next` now takes `&mut self` and returns nothing
+ - `MenuListItem` is now object-safe
 
 ## Removed
 

--- a/examples/scrolling_slice.rs
+++ b/examples/scrolling_slice.rs
@@ -5,7 +5,9 @@ use embedded_graphics_simulator::{
     BinaryColorTheme, OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent, Window,
 };
 use embedded_menu::{
-    interaction::simulator::Simulator, items::MenuItem, Menu, MenuStyle, SelectValue,
+    interaction::simulator::Simulator,
+    items::{MenuItem, MenuListItem},
+    Menu, MenuStyle, SelectValue,
 };
 
 #[derive(Copy, Clone, PartialEq, SelectValue)]
@@ -27,15 +29,16 @@ fn main() -> Result<(), core::convert::Infallible> {
         MenuItem::new("Check this 1", false),
         MenuItem::new("Check this 2", false),
     ];
-    let selects2 = [
-        MenuItem::new("Check this 3", true),
-        MenuItem::new("Check this 4", true),
-    ];
+
+    let mut item1 = MenuItem::new("Check this 3", true);
+    let mut item2 = MenuItem::new("Check this 4", true);
+
+    let dyn_selects: [&mut dyn MenuListItem<_>; 2] = [&mut item1, &mut item2];
 
     let mut menu = Menu::with_style("Menu", style)
         .add_item("Foo", ">", |_| ())
         .add_menu_items(selects1)
-        .add_menu_items(selects2)
+        .add_menu_items(dyn_selects)
         .add_item("Foo", "<-", |_| ())
         .add_item("Check this", false, |_| ())
         .add_item("Check this too", TestEnum::A, |_| ())

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -1,1 +1,89 @@
+use embedded_graphics::{
+    prelude::{Dimensions, DrawTarget, PixelColor},
+    primitives::Rectangle,
+    Pixel,
+};
+
 pub mod color_map;
+
+/// An object-safe abstraction over a display.
+pub trait Canvas<C: PixelColor> {
+    fn draw_pixel(&mut self, px: Pixel<C>) -> Result<(), ()>;
+    fn bounds(&self) -> Rectangle;
+}
+
+impl<C: PixelColor> DrawTarget for &mut dyn Canvas<C> {
+    type Color = C;
+    type Error = ();
+
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Pixel<Self::Color>>,
+    {
+        for pixel in pixels.into_iter() {
+            self.draw_pixel(pixel)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<C: PixelColor> Dimensions for &mut dyn Canvas<C> {
+    fn bounding_box(&self) -> Rectangle {
+        self.bounds()
+    }
+}
+
+/// Turns a [`DrawTarget`]` into something object safe through [`Canvas`].
+pub struct DrawTargetWrapper<C, D>
+where
+    C: PixelColor,
+    D: DrawTarget<Color = C>,
+{
+    display: D,
+    last_result: Result<(), D::Error>,
+    _marker: core::marker::PhantomData<C>,
+}
+
+impl<'a, C, D> DrawTargetWrapper<C, D>
+where
+    C: PixelColor,
+    D: DrawTarget<Color = C>,
+{
+    pub fn new(display: D) -> Self {
+        Self {
+            display,
+            last_result: Ok(()),
+            _marker: core::marker::PhantomData,
+        }
+    }
+
+    pub fn into_result(self) -> Result<(), D::Error> {
+        self.last_result
+    }
+
+    fn update_result(&mut self, result: Result<(), D::Error>) -> Result<(), ()> {
+        match result {
+            Ok(_) => Ok(()),
+            Err(err) => {
+                self.last_result = Err(err);
+                Err(())
+            }
+        }
+    }
+}
+
+impl<C, D> Canvas<C> for DrawTargetWrapper<C, D>
+where
+    C: PixelColor,
+    D: DrawTarget<Color = C>,
+{
+    fn draw_pixel(&mut self, px: Pixel<C>) -> Result<(), ()> {
+        let result = self.display.draw_iter(core::iter::once(px));
+        self.update_result(result)
+    }
+
+    fn bounds(&self) -> Rectangle {
+        self.display.bounding_box()
+    }
+}

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -3,12 +3,15 @@ use core::marker::PhantomData;
 use embedded_graphics::{
     mono_font::MonoTextStyle,
     pixelcolor::BinaryColor,
-    prelude::{DrawTarget, Point, Size},
+    prelude::{Point, Size},
     primitives::Rectangle,
 };
 use embedded_layout::{object_chain::ChainElement, prelude::*, view_group::ViewGroup};
 
-use crate::items::{Marker, MenuListItem};
+use crate::{
+    adapters::Canvas,
+    items::{Marker, MenuListItem},
+};
 
 /// Menu-related extensions for object chain elements
 pub trait MenuItemCollection<R> {
@@ -18,13 +21,11 @@ pub trait MenuItemCollection<R> {
     /// Whether an item is selectable. If not, the item will be skipped.
     fn selectable(&self, nth: usize) -> bool;
     fn count(&self) -> usize;
-    fn draw_styled<D>(
+    fn draw_styled(
         &self,
         text_style: &MonoTextStyle<'static, BinaryColor>,
-        display: &mut D,
-    ) -> Result<(), D::Error>
-    where
-        D: DrawTarget<Color = BinaryColor>;
+        display: &mut dyn Canvas<BinaryColor>,
+    ) -> Result<(), ()>;
 }
 
 // Treat any MenuItem impl as a 1-element collection
@@ -56,14 +57,11 @@ where
         1
     }
 
-    fn draw_styled<D>(
+    fn draw_styled(
         &self,
         text_style: &MonoTextStyle<'static, BinaryColor>,
-        display: &mut D,
-    ) -> Result<(), D::Error>
-    where
-        D: DrawTarget<Color = BinaryColor>,
-    {
+        display: &mut dyn Canvas<BinaryColor>,
+    ) -> Result<(), ()> {
         MenuListItem::draw_styled(self, text_style, display)
     }
 }
@@ -125,14 +123,11 @@ where
         self.items.as_ref().len()
     }
 
-    fn draw_styled<D>(
+    fn draw_styled(
         &self,
         text_style: &MonoTextStyle<'static, BinaryColor>,
-        display: &mut D,
-    ) -> Result<(), D::Error>
-    where
-        D: DrawTarget<Color = BinaryColor>,
-    {
+        display: &mut dyn Canvas<BinaryColor>,
+    ) -> Result<(), ()> {
         for item in self.items.as_ref() {
             item.draw_styled(text_style, display)?;
         }
@@ -210,14 +205,11 @@ where
         self.object.count()
     }
 
-    fn draw_styled<D>(
+    fn draw_styled(
         &self,
         text_style: &MonoTextStyle<'static, BinaryColor>,
-        display: &mut D,
-    ) -> Result<(), D::Error>
-    where
-        D: DrawTarget<Color = BinaryColor>,
-    {
+        display: &mut dyn Canvas<BinaryColor>,
+    ) -> Result<(), ()> {
         self.object.draw_styled(text_style, display)
     }
 }
@@ -267,14 +259,11 @@ where
         self.object.count() + self.parent.count()
     }
 
-    fn draw_styled<D>(
+    fn draw_styled(
         &self,
         text_style: &MonoTextStyle<'static, BinaryColor>,
-        display: &mut D,
-    ) -> Result<(), D::Error>
-    where
-        D: DrawTarget<Color = BinaryColor>,
-    {
+        display: &mut dyn Canvas<BinaryColor>,
+    ) -> Result<(), ()> {
         self.parent.draw_styled(text_style, display)?;
         self.object.draw_styled(text_style, display)?;
 

--- a/src/items/menu_item.rs
+++ b/src/items/menu_item.rs
@@ -1,12 +1,12 @@
 use embedded_graphics::{
-    mono_font::MonoTextStyle,
-    pixelcolor::BinaryColor,
-    prelude::{DrawTarget, Point},
-    primitives::Rectangle,
+    mono_font::MonoTextStyle, pixelcolor::BinaryColor, prelude::Point, primitives::Rectangle,
 };
 use embedded_layout::View;
 
-use crate::items::{Marker, MenuLine, MenuListItem};
+use crate::{
+    adapters::Canvas,
+    items::{Marker, MenuLine, MenuListItem},
+};
 
 pub trait SelectValue: Sized + Clone + PartialEq {
     /// Transforms the value on interaction
@@ -140,14 +140,11 @@ where
         self.line = MenuLine::new(longest.marker(), text_style);
     }
 
-    fn draw_styled<D>(
+    fn draw_styled(
         &self,
         text_style: &MonoTextStyle<'static, BinaryColor>,
-        display: &mut D,
-    ) -> Result<(), D::Error>
-    where
-        D: DrawTarget<Color = BinaryColor>,
-    {
+        display: &mut dyn Canvas<BinaryColor>,
+    ) -> Result<(), ()> {
         self.line.draw_styled(
             self.title_text.as_ref(),
             self.value.marker(),


### PR DESCRIPTION
Eww... technically this works, but... why 😭

Closes #14

In my tests, this caused a bit of binary bloat which would be nice to avoid. The absolutely insane levels of indirection don't help the PR.