### PR TITLE
Set "margin" module to public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,7 @@ pub mod interaction;
 pub mod items;
 pub mod selection_indicator;
 pub mod theme;
-
-mod margin;
+pub mod margin;
 
 use crate::{
     builder::MenuBuilder,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,9 @@ pub mod builder;
 pub mod collection;
 pub mod interaction;
 pub mod items;
+pub mod margin;
 pub mod selection_indicator;
 pub mod theme;
-pub mod margin;
 
 use crate::{
     builder::MenuBuilder,


### PR DESCRIPTION
Straightforward change, but I see no reason the margin module should be private, as it's the only piece missing from allowing the user to implement their own selection indicators

Outstanding work on this project by the way 